### PR TITLE
Issue/#45 fix stop fetching

### DIFF
--- a/components/PreviewCardHeader/PreviewCardHeader.vue
+++ b/components/PreviewCardHeader/PreviewCardHeader.vue
@@ -62,7 +62,7 @@
 <script lang="ts">
 import { defineComponent, PropType } from "vue";
 import { EVENT_TYPES } from "~/config/constants";
-import { OneOfValues } from "~/config/types";
+import { TEventType } from "~/config/types";
 import IconSvg from "~/components/IconSvg/IconSvg.vue";
 
 export default defineComponent({
@@ -76,8 +76,7 @@ export default defineComponent({
     },
     eventType: {
       type: String,
-      validator: (val: OneOfValues<typeof EVENT_TYPES>) =>
-        Object.values(EVENT_TYPES).includes(val),
+      validator: (val: TEventType) => Object.values(EVENT_TYPES).includes(val),
       required: true,
     },
     eventId: {

--- a/config/types.ts
+++ b/config/types.ts
@@ -1,9 +1,13 @@
-import {EVENT_TYPES} from "~/config/constants";
+import {EVENT_TYPES, ALL_EVENTS} from "~/config/constants";
 
 export type OneOfValues<T> = T[keyof T];
 export type EventId = string;
 export type StatusCode = number; // TODO: update type
 export type Email = string; // TODO: update type
+
+export type TEventType = OneOfValues<typeof EVENT_TYPES>;
+export type TEventGroup = OneOfValues<typeof EVENT_TYPES | typeof ALL_EVENTS>;
+
 
 type SMTPUser = {
   name: string;
@@ -314,7 +318,7 @@ export type Inspector = InspectorTransaction[] | InspectorSegment[];
 
 export interface ServerEvent<T> {
   uuid: EventId,
-  type: OneOfValues<typeof EVENT_TYPES> | string,
+  type: TEventType | string,
   payload: T,
   project_id: string | null,
   timestamp: number
@@ -322,7 +326,7 @@ export interface ServerEvent<T> {
 
 export interface NormalizedEvent {
   id: EventId,
-  type: OneOfValues<typeof EVENT_TYPES> | string,
+  type: TEventType | string,
   labels: string[],
   origin: object | null,
   serverName: string,

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -164,7 +164,7 @@ export default defineComponent({
 }
 
 .events-page__btn-stop-events--active {
-  @apply opacity-100 text-blue-500;
+  @apply opacity-100 text-blue-500 dark:text-blue-500;
 }
 
 .events-page__btn-stop-events-count {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -50,6 +50,7 @@ import { useNuxtApp } from "#app";
 import PreviewEventMapper from "~/components/PreviewEventMapper/PreviewEventMapper.vue";
 import { ALL_EVENTS } from "~/config/constants";
 import pluralize from "pluralize";
+import { TEventGroup } from "~/config/types";
 
 export default defineComponent({
   components: {
@@ -117,15 +118,15 @@ export default defineComponent({
         return $events.removeAll();
       }
 
-      return $events.removeByType(this.type);
+      return $events.removeByType(this.type as TEventGroup);
     },
     toggleUpdate() {
       const { $cachedEvents } = useNuxtApp();
 
       if (this.isEventsPaused) {
-        $cachedEvents.runUpdatesByType(this.type);
+        $cachedEvents.runUpdatesByType(this.type as TEventGroup);
       } else {
-        $cachedEvents.stopUpdatesByType(this.type);
+        $cachedEvents.stopUpdatesByType(this.type as TEventGroup);
       }
     },
   },

--- a/plugins/events.client.ts
+++ b/plugins/events.client.ts
@@ -42,7 +42,7 @@ export default defineNuxtPlugin(() => {
     getEventsAll.then((events: ServerEvent<unknown>[]) => {
       if (events.length) {
         eventsStore.addList(events);
-        cachedIdsStore.sanitizeWithEvents(events);
+        cachedIdsStore.syncWithActive(events.map(({ uuid }) => uuid));
       } else {
         // NOTE: clear cached events hardly
         eventsStore.removeAll();

--- a/plugins/events.client.ts
+++ b/plugins/events.client.ts
@@ -38,6 +38,7 @@ export default defineNuxtPlugin(() => {
     getEventsAll.then((events: ServerEvent<unknown>[]) => {
       if (events.length) {
         eventsStore.addEvents(events);
+        eventsStore.sanitizeCachedEvents(events);
       } else {
         // NOTE: clear cached events hardly
         eventsStore.removeEvents();
@@ -64,8 +65,8 @@ export default defineNuxtPlugin(() => {
       },
       cachedEvents: {
         eventsIdsByType: cachedEventsIdsMap,
-        stopUpdatesByType: eventsStore.setCachedEvents,
-        runUpdatesByType: eventsStore.removeCachedEvents,
+        stopUpdatesByType: eventsStore.setCachedEventsByType,
+        runUpdatesByType: eventsStore.removeCachedEventsByType,
       }
     }
   }

--- a/stores/cached-ids.ts
+++ b/stores/cached-ids.ts
@@ -1,0 +1,93 @@
+import { defineStore } from "pinia";
+import { EventId, ServerEvent, TEventGroup, TEventType } from "~/config/types";
+import { ALL_EVENTS, EVENT_TYPES, LOCAL_STORAGE_KEYS } from "~/config/constants";
+import { useEventStore } from "~/stores/events";
+
+
+type TCachedEventsEmptyMap = Record<TEventType, EventId[]>;
+
+const initialcachedIds: TCachedEventsEmptyMap = {
+  [EVENT_TYPES.SENTRY]: [] as EventId[],
+  [EVENT_TYPES.INSPECTOR]: [] as EventId[],
+  [EVENT_TYPES.PROFILER]: [] as EventId[],
+  [EVENT_TYPES.SMTP]: [] as EventId[],
+  [EVENT_TYPES.RAY_DUMP]: [] as EventId[],
+  [EVENT_TYPES.VAR_DUMP]: [] as EventId[],
+  [EVENT_TYPES.HTTP_DUMP]: [] as EventId[],
+  [ALL_EVENTS]: [] as EventId[],
+};
+
+const { localStorage } = window;
+const getCachedIds = (): TCachedEventsEmptyMap => {
+  const storageValue = localStorage?.getItem(LOCAL_STORAGE_KEYS.CACHED_EVENTS);
+
+  if (storageValue) {
+    return JSON.parse(storageValue) as TCachedEventsEmptyMap;
+  }
+
+  return initialcachedIds;
+};
+
+const syncLocalStorage = (cachedEventMap: TCachedEventsEmptyMap) => {
+  localStorage?.setItem(LOCAL_STORAGE_KEYS.CACHED_EVENTS, JSON.stringify(cachedEventMap));
+}
+
+export const useCachedIdsStore = defineStore("useCachedIdsStore", {
+  state: () => ({
+    cachedIds: getCachedIds(),
+  }),
+  getters: {
+    cachedTypesList(state) {
+      return Object.entries(state.cachedIds).filter(([_, value]) => value.length > 0).map(([key]) => key)
+    }
+  },
+  actions: {
+    setByType(cachedType: TEventGroup) {
+      const { events } =  useEventStore();
+
+      events
+        .filter(({ type }) =>
+          cachedType === ALL_EVENTS ? true : type === cachedType
+        )
+        .forEach((event) => {
+          this.cachedIds[cachedType].push(event.uuid);
+        });
+
+      syncLocalStorage(this.cachedIds);
+    },
+    removeByType(type: TEventGroup) {
+      this.cachedIds[type].length = 0;
+      syncLocalStorage(this.cachedIds);
+    },
+    removeById(eventUuid: EventId) {
+      this.cachedTypesList.forEach((type) => {
+        this.cachedIds[type] = this.cachedIds[type].filter(
+          (uuid: EventId) => uuid !== eventUuid
+        );
+      });
+
+      syncLocalStorage(this.cachedIds);
+    },
+    removeAll() {
+      this.cachedIds = initialcachedIds;
+      syncLocalStorage(this.cachedIds);
+    },
+    sanitizeWithEvents(events: ServerEvent<unknown>[]) {
+      if (!events.length) {
+        this.removeAll();
+
+        return;
+      }
+
+      const eventsIds = events.map(({ uuid }) => uuid);
+
+      this.cachedTypesList.forEach((type) => {
+        this.cachedIds[type] = this.cachedIds[type].filter(
+          (uuid: EventId) => eventsIds.includes(uuid)
+        );
+      });
+
+      syncLocalStorage(this.cachedIds);
+    }
+  }
+})

--- a/stores/cached-ids.ts
+++ b/stores/cached-ids.ts
@@ -47,7 +47,7 @@ export const useCachedIdsStore = defineStore("useCachedIdsStore", {
 
       events
         .filter(({ type }) =>
-          cachedType === ALL_EVENTS ? true : type === cachedType
+          type === cachedType || cachedType === ALL_EVENTS
         )
         .forEach((event) => {
           this.cachedIds[cachedType].push(event.uuid);
@@ -72,18 +72,16 @@ export const useCachedIdsStore = defineStore("useCachedIdsStore", {
       this.cachedIds = initialcachedIds;
       syncLocalStorage(this.cachedIds);
     },
-    sanitizeWithEvents(events: ServerEvent<unknown>[]) {
-      if (!events.length) {
+    syncWithActive(activeIds: EventId[]) {
+      if (!activeIds.length) {
         this.removeAll();
 
         return;
       }
 
-      const eventsIds = events.map(({ uuid }) => uuid);
-
       this.cachedTypesList.forEach((type) => {
         this.cachedIds[type] = this.cachedIds[type].filter(
-          (uuid: EventId) => eventsIds.includes(uuid)
+          (uuid: EventId) => activeIds.includes(uuid)
         );
       });
 

--- a/stores/events.ts
+++ b/stores/events.ts
@@ -1,47 +1,14 @@
 import { defineStore } from "pinia";
-import {
-  EventId,
-  OneOfValues,
-  ServerEvent,
-} from "~/config/types";
-import { ALL_EVENTS, EVENT_TYPES, LOCAL_STORAGE_KEYS } from "~/config/constants";
+import { EventId, ServerEvent, TEventType } from "~/config/types";
 
-type TCachedEventsEmptyMap = Record<OneOfValues<typeof EVENT_TYPES>, EventId[]>;
-type TCachedEventsType = OneOfValues<typeof EVENT_TYPES | typeof ALL_EVENTS>;
 
-const initialCachedEventsIdsMap: TCachedEventsEmptyMap = {
-  [EVENT_TYPES.SENTRY]: [] as EventId[],
-  [EVENT_TYPES.INSPECTOR]: [] as EventId[],
-  [EVENT_TYPES.PROFILER]: [] as EventId[],
-  [EVENT_TYPES.SMTP]: [] as EventId[],
-  [EVENT_TYPES.RAY_DUMP]: [] as EventId[],
-  [EVENT_TYPES.VAR_DUMP]: [] as EventId[],
-  [EVENT_TYPES.HTTP_DUMP]: [] as EventId[],
-  [ALL_EVENTS]: [] as EventId[],
-};
-
-const { localStorage } = window;
-const getCachedEventsIdsMap = (): TCachedEventsEmptyMap => {
-  const storageValue = localStorage?.getItem(LOCAL_STORAGE_KEYS.CACHED_EVENTS);
-
-  if (storageValue) {
-    return JSON.parse(storageValue) as TCachedEventsEmptyMap;
-  }
-
-  return initialCachedEventsIdsMap;
-};
-
-const updateCachedEventsLocalStorage = (cachedEventMap: TCachedEventsEmptyMap) => {
-  localStorage?.setItem(LOCAL_STORAGE_KEYS.CACHED_EVENTS, JSON.stringify(cachedEventMap));
-}
 
 export const useEventStore = defineStore("useEventStore", {
   state: () => ({
     events: [] as ServerEvent<unknown>[],
-    cachedEventsIdsMap: getCachedEventsIdsMap(), // TODO: need to split to separate store
   }),
   actions: {
-    addEvents(events: ServerEvent<unknown>[]) {
+    addList(events: ServerEvent<unknown>[]) {
       events.forEach((event) => {
         const isExistedEvent = this.events.some((el) => el.uuid === event.uuid);
         if (!isExistedEvent) {
@@ -57,78 +24,15 @@ export const useEventStore = defineStore("useEventStore", {
         }
       });
     },
-    removeEvents() {
+    removeAll() {
       this.events.length = 0;
-
-      this.clearCachedEvents();
     },
-    removeEventById(eventUuid: EventId) {
-      const eventType = this.events.find(
-        ({ uuid }) => uuid === eventUuid
-      )?.type;
-
-      if (eventType && this.cachedEventsIdsMap[eventType]?.length) {
-        this.cachedEventsIdsMap[eventType] = this.cachedEventsIdsMap[
-          eventType
-        ].filter((uuid: EventId) => uuid !== eventUuid);
-      }
-
-      if (this.cachedEventsIdsMap[ALL_EVENTS].length) {
-        this.cachedEventsIdsMap[ALL_EVENTS] = this.cachedEventsIdsMap[
-          ALL_EVENTS
-        ].filter((uuid: EventId) => uuid !== eventUuid);
-      }
-
-      updateCachedEventsLocalStorage(this.cachedEventsIdsMap);
-
+    removeById(eventUuid: EventId) {
       this.events = this.events.filter(({ uuid }) => uuid !== eventUuid);
     },
-    removeEventsByType(eventType: OneOfValues<typeof EVENT_TYPES>) {
+    removeByType(eventType: TEventType) {
       this.events = this.events.filter(({ type }) => type !== eventType);
-
-      this.removeCachedEventsByType(eventType as TCachedEventsType);
     },
 
-    setCachedEventsByType(
-      cachedType: TCachedEventsType
-    ) {
-      this.events
-        .filter(({ type }) =>
-          cachedType === ALL_EVENTS ? true : type === cachedType
-        )
-        .forEach((event) => {
-          this.cachedEventsIdsMap[cachedType].push(event.uuid);
-        });
-
-      updateCachedEventsLocalStorage(this.cachedEventsIdsMap);
-    },
-    removeCachedEventsByType(cachedType: TCachedEventsType) {
-      this.cachedEventsIdsMap[cachedType].length = 0;
-      updateCachedEventsLocalStorage(this.cachedEventsIdsMap);
-    },
-    clearCachedEvents() {
-      this.cachedEventsIdsMap = initialCachedEventsIdsMap;
-      updateCachedEventsLocalStorage(this.cachedEventsIdsMap);
-    },
-    sanitizeCachedEvents(events: ServerEvent<unknown>[]) {
-      if (!events.length) {
-        this.clearCachedEvents();
-
-        return;
-      }
-
-      const cachedEventsKeys = Object.entries(this.cachedEventsIdsMap).filter(([_, value]) => value.length > 0).map(([key]) => key);
-      const eventsIds = events.map(({ uuid }) => uuid);
-
-      cachedEventsKeys.forEach((key) => {
-        const type = key as TCachedEventsType
-
-        this.cachedEventsIdsMap[type] = this.cachedEventsIdsMap[type].filter(
-          (uuid: EventId) => eventsIds.includes(uuid)
-        );
-      });
-
-      updateCachedEventsLocalStorage(this.cachedEventsIdsMap);
-    }
   },
 });

--- a/stores/events.ts
+++ b/stores/events.ts
@@ -38,7 +38,7 @@ const updateCachedEventsLocalStorage = (cachedEventMap: TCachedEventsEmptyMap) =
 export const useEventStore = defineStore("useEventStore", {
   state: () => ({
     events: [] as ServerEvent<unknown>[],
-    cachedEventsIdsMap: getCachedEventsIdsMap(),
+    cachedEventsIdsMap: getCachedEventsIdsMap(), // TODO: need to split to separate store
   }),
   actions: {
     addEvents(events: ServerEvent<unknown>[]) {

--- a/utils/events-transport.ts
+++ b/utils/events-transport.ts
@@ -1,6 +1,5 @@
 import {Centrifuge} from 'centrifuge'
-import {EventId, OneOfValues, ServerEvent} from "~/config/types";
-import {EVENT_TYPES} from "~/config/constants";
+import { EventId, ServerEvent, TEventType } from "~/config/types";
 
 // A developer not always has a possibility to configure ENV variables,
 // so we need to guess Api and WS connection urls.
@@ -63,7 +62,7 @@ export const apiTransport = ({onEventReceiveCb, loggerCb = defaultLogger,}: ApiC
     centrifuge.rpc(`delete:api/events`, undefined)
   }
 
-  const deleteEventsByType = (type: OneOfValues<typeof EVENT_TYPES>) => {
+  const deleteEventsByType = (type: TEventType) => {
     centrifuge.rpc(`delete:api/events`, {type})
   }
 


### PR DESCRIPTION
[#45 ] Fix "stop autofetch events" logic

- [x] - use additional logic to clear outdated events ids on page reload
- [x] - refactor cached event logic to use separate store
- [x] - refactor event store actions names
- [x] - add types for event Types and event groups (page types) 
- [x] - fix active "stop fetching" action in dark theme  
 