### PR TITLE
Fixes ordering for loaded events by API

### DIFF
--- a/stores/events.ts
+++ b/stores/events.ts
@@ -10,7 +10,7 @@ export const useEventStore = defineStore("useEventStore", {
       events.forEach((event) => {
         const isExistedEvent = this.events.some((el) => el.uuid === event.uuid);
         if (!isExistedEvent) {
-          this.events.unshift(event);
+          this.events.push(event);
         } else {
           this.events = this.events.map((el) => {
             if (el.uuid !== event.uuid) {


### PR DESCRIPTION
This PR addresses an issue regarding the ordering of events after a page reload. Initially, all requested events are correctly fetched in descending order. However, a discrepancy arises when the frontend adds new events to the local store. Instead of inserting new events at the beginning of the array, which would maintain the descending order, they are appended to the end. This fix ensures that new events are correctly placed at the start of the array.

fixes #80