### PR TITLE
bugfixes for ligth theme

### DIFF
--- a/assets/mixins.scss
+++ b/assets/mixins.scss
@@ -95,3 +95,7 @@
       transform: translate(24px, 0);
     }
 }
+
+@mixin code-example {
+  @apply text-white border bg-gray-800 p-2 border-gray-300 dark:border-gray-600;
+}

--- a/src/entities/ray/ui/ray-application-log/ray-application-log.vue
+++ b/src/entities/ray/ui/ray-application-log/ray-application-log.vue
@@ -13,7 +13,10 @@ defineProps<Props>();
 </template>
 
 <style lang="scss" scoped>
+@import "assets/mixins";
+
 .ray-application-log {
-  @apply p-3 border border-gray-300 dark:border-gray-600 bg-gray-800 flex w-full overflow-auto;
+  @include code-example();
+  @apply flex w-full overflow-auto;
 }
 </style>

--- a/src/entities/sentry/ui/preview-card/preview-card.vue
+++ b/src/entities/sentry/ui/preview-card/preview-card.vue
@@ -77,8 +77,8 @@ const exception: Ref<Exception> = computed(() =>
 }
 
 .preview-card__text {
-  @include text-muted;
-  @apply text-sm break-all mb-3 p-3 dark:bg-gray-800 overflow-auto;
+  @include code-example();
+  @apply text-sm break-all mb-3 overflow-auto text-opacity-60;
 }
 
 .preview-card__frames {

--- a/src/entities/sentry/ui/sentry-exception/sentry-exception-frame.vue
+++ b/src/entities/sentry/ui/sentry-exception/sentry-exception-frame.vue
@@ -132,7 +132,8 @@ const toggleOpen = () => {
 }
 
 .sentry-exception-frame__body {
-  @apply bg-gray-900 p-2 overflow-x-scroll;
+  @include code-example();
+  @apply overflow-x-scroll;
 }
 
 .sentry-exception-frame__body-line {

--- a/src/screens/sentry/ui/sentry-page-app/sentry-page-app.vue
+++ b/src/screens/sentry/ui/sentry-page-app/sentry-page-app.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { SentryContextApp } from "~/src/entities/sentry/types";
+import type { SentryContextApp } from "~/src/entities/sentry/types";
 import { TableBaseRow, TableBase, CodeSnippet } from "~/src/shared/ui";
 
 type Props = {

--- a/src/screens/sentry/ui/sentry-page-breadcrumbs/sentry-page-breadcrumbs.vue
+++ b/src/screens/sentry/ui/sentry-page-breadcrumbs/sentry-page-breadcrumbs.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import moment from "moment";
-import { SentryBreadcrumb } from "~/src/entities/sentry/types";
+import type { SentryBreadcrumb } from "~/src/entities/sentry/types";
 import { CodeSnippet } from "~/src/shared/ui";
 
 type Props = {

--- a/src/screens/sentry/ui/sentry-page-device/sentry-page-device.vue
+++ b/src/screens/sentry/ui/sentry-page-device/sentry-page-device.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import moment from "moment";
-import { SentryDevice } from "~/src/entities/sentry/types";
+import type { SentryDevice } from "~/src/entities/sentry/types";
 import { useFormats } from "~/src/shared/lib/formats";
 import { TableBase, TableBaseRow, CodeSnippet } from "~/src/shared/ui";
 

--- a/src/screens/sentry/ui/sentry-page-request/sentry-page-request.vue
+++ b/src/screens/sentry/ui/sentry-page-request/sentry-page-request.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { SentryRequest } from "~/src/entities/sentry/types";
+import type { SentryRequest } from "~/src/entities/sentry/types";
 import { TableBase, TableBaseRow } from "~/src/shared/ui";
 
 type Props = {

--- a/src/shared/ui/value-dump/value-dump.vue
+++ b/src/shared/ui/value-dump/value-dump.vue
@@ -55,11 +55,14 @@ onMounted(() => {
 </template>
 
 <style lang="scss" scoped>
+@import "assets/mixins";
+
 .value-dump {
   display: block;
 }
 
 .value-dump__html {
-  @apply border-gray-300 dark:border-gray-600 divide-gray-300 dark:divide-gray-600 font-mono py-2 px-2 md:px-3 lg:px-4 border bg-gray-900 text-white break-all text-2xs sm:text-xs md:text-sm lg:text-base;
+  @include code-example();
+  @apply divide-gray-300 dark:divide-gray-600 font-mono md:px-3 lg:px-4 break-all text-2xs sm:text-xs md:text-sm lg:text-base;
 }
 </style>


### PR DESCRIPTION
- [x] - Update code snippet styles for light theme
- [x] - fix sentry event page opens 

Colors before change: 
<img width="585" alt="Buggregator 2023-12-10 15-12-00" src="https://github.com/buggregator/frontend/assets/13301570/94fe6536-eaad-4352-9c19-b6476cfce837">

Colors after change:
<img width="389" alt="Buggregator 2023-12-10 15-13-28" src="https://github.com/buggregator/frontend/assets/13301570/85bfdffb-6528-4f0c-b97c-27773eb07cad">
<img width="385" alt="Buggregator 2023-12-10 15-13-55" src="https://github.com/buggregator/frontend/assets/13301570/9a67455a-170a-4fb8-9a6b-3c71885f1029">
