### PR TITLE
Fix js-error in page-header component

### DIFF
--- a/src/widgets/ui/page-header/page-header.vue
+++ b/src/widgets/ui/page-header/page-header.vue
@@ -3,7 +3,7 @@ import { IconSvg } from "~/src/shared/ui";
 
 type Props = {
   title?: string;
-  buttonTitle: string;
+  buttonTitle?: string;
 };
 
 type Emits = {


### PR DESCRIPTION
Added optional chaining to buttonTitle-property of page-header component to fix errors throwing when no butto-title is set from page.