### PR TITLE
[bugfix] fix ray event style

### DIFF
--- a/src/entities/ray/ui/ray-event/ray-event.vue
+++ b/src/entities/ray/ui/ray-event/ray-event.vue
@@ -26,7 +26,8 @@ defineProps<Props>();
 }
 
 .ray-event__text {
-  @apply p-3 border border-gray-300 dark:border-gray-600 bg-gray-800 flex w-full overflow-auto;
+  @apply p-3 border flex w-full overflow-auto;
+  @apply border-gray-300 text-gray-200 bg-gray-800;
 }
 
 .ray-event__text-in {


### PR DESCRIPTION
Fix for ray event content

Before:
<img width="338" alt="Events+100++Buggregator+2024-05-09+09-06-52" src="https://github.com/buggregator/frontend/assets/13301570/79f45a5f-5574-4de1-85de-4c7575168c0f">

After:
<img width="335" alt="Events+100++Buggregator+2024-05-09+09-09-19" src="https://github.com/buggregator/frontend/assets/13301570/ed2db725-7449-4913-8224-a149cb90f689">
