### PR TITLE
[#154] add var-dump label

### DIFF
--- a/src/entities/var-dump/lib/normalize-var-dump-event.ts
+++ b/src/entities/var-dump/lib/normalize-var-dump-event.ts
@@ -2,16 +2,24 @@ import type { ServerEvent, NormalizedEvent } from "~/src/shared/types";
 import { EVENT_TYPES } from "~/src/shared/types";
 import type { VarDump } from "../types";
 
-export const normalizeVarDumpEvent = (event: ServerEvent<VarDump>): NormalizedEvent<VarDump> => ({
-  id: event.uuid,
-  type: EVENT_TYPES.VAR_DUMP,
-  labels: [EVENT_TYPES.VAR_DUMP],
-  origin: {
-    file: event.payload.context.source.file,
-    name: event.payload.context.source.name,
-    line_number: event.payload.context.source.line,
-  },
-  serverName: "",
-  date: event.timestamp ? new Date(event.timestamp * 1000) : null,
-  payload: event.payload
-})
+export const normalizeVarDumpEvent = (event: ServerEvent<VarDump>): NormalizedEvent<VarDump> => {
+  const normalizedEvent: NormalizedEvent<VarDump> = {
+    id: event.uuid,
+    type: EVENT_TYPES.VAR_DUMP,
+    labels: [EVENT_TYPES.VAR_DUMP],
+    origin: {
+      file: event.payload.context.source.file,
+      name: event.payload.context.source.name,
+      line_number: event.payload.context.source.line,
+    },
+    serverName: "",
+    date: event.timestamp ? new Date(event.timestamp * 1000) : null,
+    payload: event.payload
+  }
+
+  if (event.payload?.payload?.label != null) {
+    normalizedEvent.labels.push(`label: ${event.payload.payload.label}`);
+  }
+
+  return normalizedEvent;
+}

--- a/src/entities/var-dump/types.ts
+++ b/src/entities/var-dump/types.ts
@@ -1,5 +1,6 @@
 export interface VarDump {
   payload: {
+    label: string | null,
     type: string,
     value: string | number | boolean
   },


### PR DESCRIPTION
#154 
Var dump events with new labels
<img width="607" alt="Events+11++Buggregator+2024-06-07+19-16-00" src="https://github.com/buggregator/frontend/assets/13301570/f5bbf3ce-725b-4ade-a633-63ecce347dfa">


@butschster Does this look like what you expected?
