### PR TITLE
Sets Wall Time as a default metric for call graph profiler

### DIFF
--- a/src/screens/profiler/ui/call-graph/call-graph.vue
+++ b/src/screens/profiler/ui/call-graph/call-graph.vue
@@ -13,7 +13,7 @@ type Props = {
 
 const props = defineProps<Props>();
 const isFullscreen = ref(false);
-const metric = ref(GraphTypes.CPU as GraphTypes);
+const metric = ref(GraphTypes.WALL_TIME as GraphTypes);
 const threshold = ref(1);
 const percent = ref(10);
 


### PR DESCRIPTION
![image](https://github.com/buggregator/frontend/assets/773481/2fe903fe-da97-4ab8-9972-2a28cc7a8578)
