### PR TITLE
Issue/#103 extend sentry report

### DIFF
--- a/src/entities/sentry/types.ts
+++ b/src/entities/sentry/types.ts
@@ -42,6 +42,7 @@ export type SentryContexts = Omit<SentryTypes.Contexts, 'device' | 'app'> & {
 }
 
 export interface Sentry extends Omit<SentryTypes.Event, 'request' | 'exception' | 'breadcrumbs' | 'level' | 'contexts'> {
+  platform?: string,
   contexts?: SentryContexts,
   request?: SentryRequest,
   exception?: {
@@ -50,5 +51,11 @@ export interface Sentry extends Omit<SentryTypes.Event, 'request' | 'exception' 
   breadcrumbs?: {
     values: SentryBreadcrumb[]
   },
-  level?: SentryLevel
+  level?: SentryLevel,
+  modules?: {
+    [key: string]: string
+  },
+  extra?: {
+    environment?: Record<string, string>,
+  }
 }

--- a/src/entities/sentry/types.ts
+++ b/src/entities/sentry/types.ts
@@ -54,8 +54,5 @@ export interface Sentry extends Omit<SentryTypes.Event, 'request' | 'exception' 
   level?: SentryLevel,
   modules?: {
     [key: string]: string
-  },
-  extra?: {
-    environment?: Record<string, string>,
   }
 }

--- a/src/screens/sentry/ui/sentry-page-extra/index.ts
+++ b/src/screens/sentry/ui/sentry-page-extra/index.ts
@@ -1,0 +1,3 @@
+import SentryPageExtra from './sentry-page-extra.vue'
+
+export { SentryPageExtra }

--- a/src/screens/sentry/ui/sentry-page-extra/sentry-page-extra.stories.ts
+++ b/src/screens/sentry/ui/sentry-page-extra/sentry-page-extra.stories.ts
@@ -12,12 +12,12 @@ export default {
 
 export const Laravel: StoryObj<typeof SentryPageExtra> = {
   args: {
-    request: normalizeSentryEvent(sentryLaravelMock).payload.extra,
+    extra: normalizeSentryEvent(sentryLaravelMock).payload.extra,
   }
 };
 
 export const Spiral: StoryObj<typeof SentryPageExtra> = {
   args: {
-    request: normalizeSentryEvent(sentrySpiralMock).payload.extra,
+    extra: normalizeSentryEvent(sentrySpiralMock).payload.extra,
   }
 };

--- a/src/screens/sentry/ui/sentry-page-extra/sentry-page-extra.stories.ts
+++ b/src/screens/sentry/ui/sentry-page-extra/sentry-page-extra.stories.ts
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/vue3";
+import { useSentry } from "~/src/entities/sentry";
+import { sentryLaravelMock, sentrySpiralMock } from '~/src/entities/sentry/mocks';
+import SentryPageExtra from './sentry-page-extra.vue';
+
+const { normalizeSentryEvent } = useSentry();
+
+export default {
+  title: "Screens/sentry/SentryPageExtra",
+  component: SentryPageExtra
+} as Meta<typeof SentryPageExtra>;
+
+export const Laravel: StoryObj<typeof SentryPageExtra> = {
+  args: {
+    request: normalizeSentryEvent(sentryLaravelMock).payload.extra,
+  }
+};
+
+export const Spiral: StoryObj<typeof SentryPageExtra> = {
+  args: {
+    request: normalizeSentryEvent(sentrySpiralMock).payload.extra,
+  }
+};

--- a/src/screens/sentry/ui/sentry-page-extra/sentry-page-extra.vue
+++ b/src/screens/sentry/ui/sentry-page-extra/sentry-page-extra.vue
@@ -1,0 +1,113 @@
+<script lang="ts" setup>
+import { ref } from "vue";
+import type { Sentry } from "~/src/entities/sentry/types";
+import { IconSvg, TableBase, TableBaseRow } from "~/src/shared/ui";
+
+type Props = {
+  extra: Sentry["extra"];
+};
+
+const props = defineProps<Props>();
+
+const ddStates = ref(
+  Object.keys(props.extra || {}).reduce(
+    (acc, key) => {
+      acc[key] = false;
+      return acc;
+    },
+    {} as Record<string, boolean>,
+  ),
+);
+</script>
+
+<template>
+  <section class="sentry-page-extra">
+    <h3 class="sentry-page-extra__head">Extra</h3>
+
+    <div class="sentry-page-extra__in">
+      <div
+        v-for="(value, key) in extra"
+        :key="key"
+        class="sentry-page-extra__wrapper"
+        :class="{
+          'sentry-page-extra__wrapper--open': ddStates[key],
+        }"
+      >
+        <h3
+          class="sentry-page-extra__title"
+          @click="ddStates[key] = !ddStates[key]"
+        >
+          {{ key }}
+
+          <IconSvg
+            class="sentry-page-extra__title-dd"
+            :class="{
+              'sentry-page-extra__title-dd--open': ddStates[key],
+            }"
+            name="dd"
+          />
+        </h3>
+
+        <TableBase v-if="value" class="sentry-page-extra__content">
+          <TableBaseRow
+            v-for="(v, t) in value"
+            :key="t"
+            :title="String(t || '')"
+          >
+            {{ JSON.stringify(v) }}
+          </TableBaseRow>
+        </TableBase>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style lang="scss" scoped>
+@import "src/assets/mixins";
+
+.sentry-page-extra {
+}
+
+.sentry-page-extra__wrapper {
+  @apply dark:bg-gray-900 bg-gray-100 p-3 border border-purple-300 dark:border-gray-400;
+
+  &:first-child {
+    @apply rounded-t-md;
+  }
+
+  &:last-child {
+    @apply rounded-b-md;
+  }
+}
+
+.sentry-page-extra__head {
+  @include text-muted;
+  @apply font-bold uppercase text-sm flex justify-between mb-3;
+}
+
+.sentry-page-extra__title {
+  @include text-muted;
+  @apply font-bold uppercase text-sm flex justify-between;
+}
+
+.sentry-page-extra__url {
+  @apply mb-1 text-lg font-medium;
+}
+
+.sentry-page-extra__title-dd {
+  @apply ml-2 w-5 ml-auto transform rotate-180;
+}
+
+.sentry-page-extra__title-dd--open {
+  @apply rotate-0;
+}
+
+.sentry-page-extra__content {
+  display: none;
+  @apply mt-3;
+
+  .sentry-page-extra__wrapper--open & {
+    display: block;
+  }
+}
+</style>

--- a/src/screens/sentry/ui/sentry-page-request/sentry-page-request.vue
+++ b/src/screens/sentry/ui/sentry-page-request/sentry-page-request.vue
@@ -30,7 +30,7 @@ const normalizeHeaderValue = (value: unknown) =>
         <TableBaseRow
           v-for="(value, title) in request.headers"
           :key="title"
-          :title="title"
+          :title="String(title)"
         >
           {{ normalizeHeaderValue(value) }}
         </TableBaseRow>

--- a/src/screens/sentry/ui/sentry-page-tags/sentry-page-tags.vue
+++ b/src/screens/sentry/ui/sentry-page-tags/sentry-page-tags.vue
@@ -1,16 +1,19 @@
 <script lang="ts" setup>
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import type {
   Sentry,
   SentryContextRuntime,
   SentryContextOS,
 } from "~/src/entities/sentry/types";
+import { IconSvg } from "~/src/shared/ui";
 
 type Props = {
   payload: Sentry;
 };
 
 const props = defineProps<Props>();
+
+const isModulesOpen = ref(false);
 
 const contextsRuntime = computed(() => {
   const { name = "", version = "" } =
@@ -66,6 +69,15 @@ const tags = computed(() => [
     value: props.payload.server_name,
   },
 ]);
+
+const modules = computed(() => {
+  const mods = props.payload.modules || {};
+
+  return Object.keys(mods).map((name) => ({
+    name,
+    version: mods[name],
+  }));
+});
 </script>
 
 <template>
@@ -79,7 +91,7 @@ const tags = computed(() => [
     </div>
 
     <div class="sentry-page-tags__labels-wrapper">
-      <h3 class="sentry-page-tags__title">tags</h3>
+      <h3 class="sentry-page-tags__title">Tags</h3>
       <div class="sentry-page-tags__labels">
         <div
           v-for="tag in tags"
@@ -106,6 +118,40 @@ const tags = computed(() => [
         </template>
       </div>
     </div>
+
+    <div
+      class="sentry-page-tags__labels-wrapper"
+      :class="{
+        'sentry-page-tags__labels-wrapper--partial': !isModulesOpen,
+      }"
+    >
+      <h3
+        class="sentry-page-tags__title"
+        @click="isModulesOpen = !isModulesOpen"
+      >
+        Modules
+
+        <IconSvg
+          class="sentry-page-tags__title-dd"
+          :class="{
+            'sentry-page-tags__title-dd--open': isModulesOpen,
+          }"
+          name="dd"
+        />
+      </h3>
+      <div class="sentry-page-tags__labels">
+        <div
+          v-for="module in modules"
+          :key="module.name"
+          class="sentry-page-tags__label"
+        >
+          <div class="sentry-page-tags__label-name">{{ module.name }}</div>
+          <div class="sentry-page-tags__label-value">
+            {{ module.version }}
+          </div>
+        </div>
+      </div>
+    </div>
   </section>
 </template>
 
@@ -117,9 +163,44 @@ const tags = computed(() => [
 
 .sentry-page-tags__title {
   @include text-muted;
-  @apply font-bold uppercase text-sm mb-5;
+  @apply font-bold uppercase text-sm flex justify-between;
 }
 
+.sentry-page-tags__title-dd {
+  @apply ml-2 w-5 ml-auto transform rotate-180;
+}
+
+.sentry-page-tags__title-dd--open {
+  @apply rotate-0;
+}
+
+.sentry-page-tags__labels-wrapper {
+  @apply bg-gray-50 dark:bg-gray-900 p-4 rounded-md border border-purple-300 dark:border-gray-400;
+
+  & + & {
+    @apply mt-5;
+  }
+}
+
+.sentry-page-tags__labels-wrapper--partial {
+  @apply max-h-[200px] overflow-y-auto;
+}
+
+.sentry-page-tags__labels {
+  @apply flex flex-row flex-wrap items-center text-purple-600 dark:text-purple-100 gap-3 mt-3;
+}
+
+.sentry-page-tags__label {
+  @apply flex border border-purple-300 rounded text-xs items-center;
+}
+
+.sentry-page-tags__label-name {
+  @apply px-3 py-1 border-r;
+}
+
+.sentry-page-tags__label-value {
+  @apply px-3 py-1 bg-purple-100 dark:bg-purple-800 rounded-r font-bold;
+}
 .sentry-page-tags__boxes {
   @apply flex items-stretch flex-col md:flex-row mb-5 gap-x-4;
 }
@@ -139,25 +220,5 @@ const tags = computed(() => [
 
 .sentry-page-tags__box-value {
   @apply text-sm;
-}
-
-.sentry-page-tags__labels {
-  @apply flex flex-row flex-wrap items-center text-purple-600 dark:text-purple-100 gap-3;
-}
-
-.sentry-page-tags__labels-wrapper {
-  @apply bg-gray-50 dark:bg-gray-900 p-4 rounded-md border border-purple-300 dark:border-gray-400;
-}
-
-.sentry-page-tags__label {
-  @apply flex border border-purple-300 rounded text-xs items-center;
-}
-
-.sentry-page-tags__label-name {
-  @apply px-3 py-1 border-r;
-}
-
-.sentry-page-tags__label-value {
-  @apply px-3 py-1 bg-purple-100 dark:bg-purple-800 rounded-r font-bold;
 }
 </style>

--- a/src/screens/sentry/ui/sentry-page-tags/sentry-page-tags.vue
+++ b/src/screens/sentry/ui/sentry-page-tags/sentry-page-tags.vue
@@ -25,74 +25,70 @@ const contextsOS = computed(() => {
 
   return { name, version };
 });
+
+const boxes = computed(() => [
+  {
+    title: "runtime",
+    name: contextsRuntime.value.name,
+    version: contextsRuntime.value.version,
+  },
+  {
+    title: "os",
+    name: contextsOS.value.name,
+    version: contextsOS.value.version,
+  },
+  {
+    title: "sdk",
+    name: props.payload.sdk?.name,
+    version: props.payload.sdk?.version,
+  },
+]);
+
+const tags = computed(() => [
+  {
+    name: "env",
+    value: props.payload.environment,
+  },
+  {
+    name: "logger",
+    value: props.payload.logger,
+  },
+  {
+    name: "os",
+    value: `${contextsOS.value.name} ${contextsOS.value.version}`,
+  },
+  {
+    name: "runtime",
+    value: `${contextsRuntime.value.name} ${contextsRuntime.value.version}`,
+  },
+  {
+    name: "server name",
+    value: props.payload.server_name,
+  },
+]);
 </script>
 
 <template>
   <section class="sentry-page-tags">
     <div class="sentry-page-tags__boxes">
-      <div v-if="contextsRuntime.name" class="sentry-page-tags__box">
-        <span class="sentry-page-tags__box-title">runtime</span>
-        <h4 class="sentry-page-tags__box-name">{{ contextsRuntime.name }}</h4>
-        <p class="sentry-page-tags__box-value">
-          Version: {{ contextsRuntime.version }}
-        </p>
-      </div>
-
-      <div v-if="contextsOS.name" class="sentry-page-tags__box">
-        <span class="sentry-page-tags__box-title">os</span>
-        <h4 class="sentry-page-tags__box-name">{{ contextsOS.name }}</h4>
-        <p class="sentry-page-tags__box-value">
-          Version: {{ contextsOS.version }}
-        </p>
-      </div>
-
-      <div v-if="payload.sdk && payload.sdk.name" class="sentry-page-tags__box">
-        <span class="sentry-page-tags__box-title">sdk</span>
-        <h4 class="sentry-page-tags__box-name">{{ payload.sdk.name }}</h4>
-        <p class="sentry-page-tags__box-value">
-          Version: {{ payload.sdk.version }}
-        </p>
+      <div v-for="box in boxes" :key="box.name" class="sentry-page-tags__box">
+        <span class="sentry-page-tags__box-title">{{ box.title }}</span>
+        <h4 class="sentry-page-tags__box-name">{{ box.name }}</h4>
+        <p class="sentry-page-tags__box-value">Version: {{ box.version }}</p>
       </div>
     </div>
 
     <div class="sentry-page-tags__labels-wrapper">
       <h3 class="sentry-page-tags__title">tags</h3>
       <div class="sentry-page-tags__labels">
-        <div class="sentry-page-tags__label">
-          <div class="sentry-page-tags__label-name">env</div>
+        <div
+          v-for="tag in tags"
+          :key="tag.name"
+          class="sentry-page-tags__label"
+        >
+          <div class="sentry-page-tags__label-name">{{ tag.name }}</div>
           <div class="sentry-page-tags__label-value">
-            {{ payload.environment }}
-          </div>
-        </div>
-
-        <div v-if="payload.release" class="sentry-page-tags__label">
-          <div class="sentry-page-tags__label-name">release</div>
-          <div class="sentry-page-tags__label-value">
-            {{ payload.release }}
-          </div>
-        </div>
-        <div v-if="payload.logger" class="sentry-page-tags__label">
-          <div class="sentry-page-tags__label-name">logger</div>
-          <div class="sentry-page-tags__label-value">
-            {{ payload.logger }}
-          </div>
-        </div>
-        <div v-if="contextsOS.name" class="sentry-page-tags__label">
-          <div class="sentry-page-tags__label-name">os</div>
-          <div class="sentry-page-tags__label-value">
-            {{ contextsOS.name }} {{ contextsOS.version }}
-          </div>
-        </div>
-        <div v-if="contextsRuntime.name" class="sentry-page-tags__label">
-          <div class="sentry-page-tags__label-name">runtime</div>
-          <div class="sentry-page-tags__label-value">
-            {{ contextsRuntime.name }} {{ contextsRuntime.version }}
-          </div>
-        </div>
-        <div v-if="payload.server_name" class="sentry-page-tags__label">
-          <div class="sentry-page-tags__label-name">server name</div>
-          <div class="sentry-page-tags__label-value">
-            {{ payload.server_name }}
+            {{ tag.value }}
           </div>
         </div>
 

--- a/src/screens/sentry/ui/sentry-page-tags/sentry-page-tags.vue
+++ b/src/screens/sentry/ui/sentry-page-tags/sentry-page-tags.vue
@@ -182,12 +182,12 @@ const modules = computed(() => {
   }
 }
 
-.sentry-page-tags__labels-wrapper--partial {
-  @apply max-h-[200px] overflow-y-auto;
-}
-
 .sentry-page-tags__labels {
   @apply flex flex-row flex-wrap items-center text-purple-600 dark:text-purple-100 gap-3 mt-3;
+
+  .sentry-page-tags__labels-wrapper--partial & {
+    @apply max-h-[200px] overflow-y-auto;
+  }
 }
 
 .sentry-page-tags__label {

--- a/src/screens/sentry/ui/sentry-page/sentry-page.vue
+++ b/src/screens/sentry/ui/sentry-page/sentry-page.vue
@@ -17,15 +17,15 @@ type Props = {
 const props = defineProps<Props>();
 
 const formattedTimestamp = computed(() =>
-  moment(props.event.payload.timestamp).toLocaleString()
+  moment(props.event.payload.timestamp).toLocaleString(),
 );
 
 const mainException = computed(
-  () => props.event.payload?.exception?.values?.[0]
+  () => props.event.payload?.exception?.values?.[0],
 );
 
 const exceptionsLength = computed(
-  () => props.event?.payload?.exception?.values?.length || 0
+  () => props.event?.payload?.exception?.values?.length || 0,
 );
 </script>
 
@@ -43,7 +43,7 @@ const exceptionsLength = computed(
         <p class="sentry-page__main-date">{{ formattedTimestamp }}</p>
       </header>
 
-      <SentryPageTags :payload="event.payload" class="sentry-page__section" />
+      <SentryPageTags class="sentry-page__section" :payload="event.payload" />
 
       <section v-if="mainException" class="sentry-page__section">
         <h3 class="sentry-page__section-title">

--- a/src/screens/sentry/ui/sentry-page/sentry-page.vue
+++ b/src/screens/sentry/ui/sentry-page/sentry-page.vue
@@ -7,6 +7,7 @@ import type { NormalizedEvent } from "~/src/shared/types";
 import { SentryPageApp } from "../sentry-page-app";
 import { SentryPageBreadcrumbs } from "../sentry-page-breadcrumbs";
 import { SentryPageDevice } from "../sentry-page-device";
+import { SentryPageExtra } from "../sentry-page-extra";
 import { SentryPageRequest } from "../sentry-page-request";
 import { SentryPageTags } from "../sentry-page-tags";
 
@@ -103,6 +104,12 @@ const exceptionsLength = computed(
         :device="event.payload.contexts.device"
         class="sentry-page__section"
       />
+
+      <SentryPageExtra
+        v-if="extra"
+        :extra="extra"
+        class="sentry-page__section"
+      />
     </main>
   </div>
 </template>
@@ -115,7 +122,7 @@ const exceptionsLength = computed(
 }
 
 .sentry-page__main {
-  @apply flex flex-col w-full;
+  @apply flex flex-col w-full pb-5;
 }
 
 .sentry-page__main-header {

--- a/src/shared/ui/table-base/table-base-row.vue
+++ b/src/shared/ui/table-base/table-base-row.vue
@@ -29,7 +29,7 @@ withDefaults(defineProps<Props>(), {
 }
 
 .table-base-row__name {
-  @apply font-bold mr-5 md:w-1/4 sm:pr-4;
+  @apply font-bold md:w-1/4 sm:pr-4 overflow-hidden text-ellipsis;
 }
 
 .table-base-row__value {

--- a/src/shared/ui/table-base/table-base-row.vue
+++ b/src/shared/ui/table-base/table-base-row.vue
@@ -13,7 +13,7 @@ withDefaults(defineProps<Props>(), {
 <template>
   <div class="table-base-row">
     <div class="table-base-row__name">
-      <span>{{ title }}</span>
+      <span :title="title">{{ title }}</span>
     </div>
     <div class="table-base-row__value">
       <slot></slot>


### PR DESCRIPTION
Enhance sentry page data report

- Add sentry page additional sections: modules, extra
- polish data-table common components


Current result:
<img width="965" alt="Monosnap Buggregator 2024-07-11 00-28-58" src="https://github.com/buggregator/frontend/assets/13301570/75f6564f-e746-4781-8b70-1de7558c5f6d">

<img width="963" alt="Monosnap Buggregator 2024-07-11 00-28-03" src="https://github.com/buggregator/frontend/assets/13301570/cc209c9c-29d1-4696-a86e-75181bbbea72">