### PR TITLE
downgrade node 22.5 to 22.4 in test workflow

### DIFF
--- a/.github/workflows/test-build-ci.yml
+++ b/.github/workflows/test-build-ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.4.x]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Actualise node version to 22.4 from 22.x (22.5.0)

Node issue: https://github.com/nodejs/node/pull/53934

