### PR TITLE
Issue/#202 monolog preview change

### DIFF
--- a/src/entities/monolog/ui/preview-card/preview-card.vue
+++ b/src/entities/monolog/ui/preview-card/preview-card.vue
@@ -16,7 +16,7 @@ const shortMessage = computed(() => {
   const lines = props.event.payload.message.split("\n");
 
   if (lines.length > 10) {
-    return `${lines.slice(0, 5).join("\n")}\n...`;
+    return `${lines.slice(0, 8).join("\n")}\n...`;
   }
 
   return props.event.payload.message;
@@ -35,7 +35,7 @@ const toggleView = () => {
       class="preview-card__snippet preview-card__snippet--interactive"
       :code="isFullMessage ? message : shortMessage"
       title="Click to show full message"
-      @click.self="toggleView"
+      @click="toggleView"
     />
 
     <CodeSnippet

--- a/src/entities/monolog/ui/preview-card/preview-card.vue
+++ b/src/entities/monolog/ui/preview-card/preview-card.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { computed, ref } from "vue";
 import type { NormalizedEvent } from "~/src/shared/types";
 import { PreviewCard, CodeSnippet } from "~/src/shared/ui";
 import type { Monolog } from "../../types";
@@ -7,12 +8,35 @@ type Props = {
   event: NormalizedEvent<Monolog>;
 };
 
-defineProps<Props>();
+const props = defineProps<Props>();
+
+const message = ref(props.event.payload.message);
+
+const shortMessage = computed(() => {
+  const lines = props.event.payload.message.split("\n");
+
+  if (lines.length > 10) {
+    return `${lines.slice(0, 5).join("\n")}\n...`;
+  }
+
+  return props.event.payload.message;
+});
+
+const isFullMessage = ref(message.value.length === shortMessage.value.length);
+
+const toggleView = () => {
+  isFullMessage.value = !isFullMessage.value;
+};
 </script>
 
 <template>
   <PreviewCard class="preview-card" :event="event">
-    <CodeSnippet class="preview-card__snippet" :code="event.payload.message" />
+    <CodeSnippet
+      class="preview-card__snippet preview-card__snippet--interactive"
+      :code="isFullMessage ? message : shortMessage"
+      title="Click to show full message"
+      @click.self="toggleView"
+    />
 
     <CodeSnippet
       v-if="event.payload.context"
@@ -32,7 +56,7 @@ defineProps<Props>();
 
 <style lang="scss" scoped>
 .preview-card {
-  @apply text-xs break-all;
+  @apply text-xs break-all relative;
 }
 
 .preview-card__snippet {
@@ -41,5 +65,13 @@ defineProps<Props>();
   & + & {
     @apply border-t-2;
   }
+}
+
+.preview-card__snippet--interactive {
+  @apply cursor-pointer;
+}
+
+.preview-card__frame {
+  @apply text-xs relative;
 }
 </style>

--- a/src/entities/monolog/ui/preview-card/preview-card.vue
+++ b/src/entities/monolog/ui/preview-card/preview-card.vue
@@ -9,17 +9,16 @@ type Props = {
 };
 
 const props = defineProps<Props>();
-
 const message = ref(props.event.payload.message);
 
 const shortMessage = computed(() => {
-  const lines = props.event.payload.message.split("\n");
+  const lines = message.value.split("\n");
 
   if (lines.length > 10) {
     return `${lines.slice(0, 8).join("\n")}\n...`;
   }
 
-  return props.event.payload.message;
+  return message.value;
 });
 
 const isFullMessage = ref(message.value.length === shortMessage.value.length);

--- a/src/entities/monolog/ui/preview-card/preview-card.vue
+++ b/src/entities/monolog/ui/preview-card/preview-card.vue
@@ -55,7 +55,7 @@ const toggleView = () => {
 
 <style lang="scss" scoped>
 .preview-card {
-  @apply text-xs break-all relative;
+  @apply text-xs break-all;
 }
 
 .preview-card__snippet {
@@ -68,9 +68,5 @@ const toggleView = () => {
 
 .preview-card__snippet--interactive {
   @apply cursor-pointer;
-}
-
-.preview-card__frame {
-  @apply text-xs relative;
 }
 </style>

--- a/src/shared/ui/code-snippet/code-snippet.vue
+++ b/src/shared/ui/code-snippet/code-snippet.vue
@@ -19,7 +19,7 @@ const props = withDefaults(defineProps<Props>(), {
 const isCopied = ref(false);
 
 const normalizedCode = computed(() =>
-  !isString(props.code) ? JSON.stringify(props.code, null, " ") : props.code
+  !isString(props.code) ? JSON.stringify(props.code, null, " ") : props.code,
 );
 
 const copyCode = (): void => {
@@ -40,21 +40,21 @@ const copyCode = (): void => {
 
 <template>
   <div class="code-snippet">
+    <button
+      type="button"
+      class="code-snippet__copy"
+      :class="{ 'code-snippet__copy--active': isCopied }"
+      @click.stop="copyCode"
+    >
+      <IconSvg name="copy" class="code-snippet__copy-icon" />
+      Copy
+    </button>
+
     <CodeHighlight
       :language="language"
       :autodetect="false"
       :code="normalizedCode"
     />
-
-    <button
-      type="button"
-      class="code-snippet__copy"
-      :class="{ 'code-snippet__copy--active': isCopied }"
-      @click="copyCode"
-    >
-      <IconSvg name="copy" class="code-snippet__copy-icon" />
-      Copy
-    </button>
   </div>
 </template>
 
@@ -69,10 +69,10 @@ const copyCode = (): void => {
   &:hover {
     @apply border-gray-200 text-white bg-gray-900;
   }
-}
 
-.code-snippet:hover .code-snippet__copy {
-  @apply visible;
+  .code-snippet:hover & {
+    @apply visible;
+  }
 }
 
 .code-snippet__copy--active {


### PR DESCRIPTION
Fix #202 

Change monolog preview for large message events.
Truncate content to max 7 lines (full view is available by click on code-snippet)

![image](https://github.com/user-attachments/assets/c228fcbd-a47c-4eb5-a2ba-597bf65d8abb)
