### PR TITLE
fix smtp iframe default height

### DIFF
--- a/pages/smtp/[id].vue
+++ b/pages/smtp/[id].vue
@@ -74,14 +74,12 @@ onMounted(getEvent);
       <div></div>
     </div>
 
-    <div>
-      <SmtpPage
-        v-if="event"
-        :event="event"
-        :attachments="attachments"
-        :html-source="html"
-      />
-    </div>
+    <SmtpPage
+      v-if="event"
+      :event="event"
+      :attachments="attachments"
+      :html-source="html"
+    />
   </NuxtLayout>
 </template>
 


### PR DESCRIPTION
Fix for SMTP page fullscreen tab


Before:
![image](https://github.com/user-attachments/assets/2a8bb7e2-c432-4e02-8e63-b55ff68223f8)


After:
![image](https://github.com/user-attachments/assets/094a896c-95ee-4ac4-9f97-f6c1188e3e64)
