### PR TITLE
fix: reduce cpu load on firefox by removing connected icon animation

### DIFF
--- a/src/shared/ui/icon-svg/icon-svg-originals/connected.svg
+++ b/src/shared/ui/icon-svg/icon-svg-originals/connected.svg
@@ -3,12 +3,9 @@
   width="100%" height="100%" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid"
 >
   <circle cx="28" cy="75" r="11" fill="#0055a5">
-    <animate attributeName="fill-opacity" repeatCount="indefinite" dur="1.1764705882352942s" values="0;1;1" keyTimes="0;0.2;1" begin="0s"></animate>
   </circle>
   <path d="M28 47A28 28 0 0 1 56 75" fill="none" stroke="#2d78bc" stroke-width="10">
-    <animate attributeName="stroke-opacity" repeatCount="indefinite" dur="1.1764705882352942s" values="0;1;1" keyTimes="0;0.2;1" begin="0.11764705882352942s"></animate>
   </path>
   <path d="M28 25A50 50 0 0 1 78 75" fill="none" stroke="#45aee7" stroke-width="10">
-    <animate attributeName="stroke-opacity" repeatCount="indefinite" dur="1.1764705882352942s" values="0;1;1" keyTimes="0;0.2;1" begin="0.23529411764705885s"></animate>
   </path>
 </svg>


### PR DESCRIPTION
## What was changed

Connected icon animation was removed

## Why?

Firefox constantly uses high cpu load when the buggregator window is visible on the screen, due to the constant animation running on the connected icon.

## Checklist

- Tested
    - [X] Tested manually
    - [ ] Unit tests added


