### PR TITLE
fix: vscode link to editor

### DIFF
--- a/src/shared/ui/preview-card/preview-card-footer.vue
+++ b/src/shared/ui/preview-card/preview-card-footer.vue
@@ -62,6 +62,10 @@ const editorLink = computed(() => {
     return ''
   }
 
+  if (codeEditor.value == 'vscode') {
+    return `vscode://file/${fileName}${line ? `:${line}` : ''}`
+  }
+
   return `${codeEditor.value}://open?file=${fileName}${line ? `&line=${line}` : ''}`
 })
 


### PR DESCRIPTION
## What was changed

A vscode-specific link to open the file in the editor was added

## Why?

vscode uses a different format to phpstorm for the link to the file, for vscode:// links

## Checklist

- Partly addresses #198
- Tested
    - [ ] Tested manually
    - [ ] Unit tests added

** Untested as I can't get the local development working on my computer, but I'm 99% sure it's good!

