### PR TITLE
Add support for links to 'zed' code editor

### DIFF
--- a/src/shared/ui/preview-card/preview-card-footer.vue
+++ b/src/shared/ui/preview-card/preview-card-footer.vue
@@ -65,6 +65,10 @@ const editorLink = computed(() => {
   if (codeEditor.value == 'vscode') {
     return `vscode://file/${fileName}${line ? `:${line}` : ''}`
   }
+  
+  if (codeEditor.value == 'zed') {
+    return `zed://file/${fileName}${line ? `:${line}` : ''}`
+  }
 
   return `${codeEditor.value}://open?file=${fileName}${line ? `&line=${line}` : ''}`
 })


### PR DESCRIPTION
## What was changed

Added support for links to open source file in zed editor

## Why?

Links were not working to open in zed

## Checklist

- Tested
    - [x] Tested manually
    - [ ] Unit tests added

## Documentation

Set the editor to _zed_ to open source code links in zed editor

