### PR TITLE
Add metric selection toolbar to flame chart

### DIFF
--- a/src/entities/profiler/ui/flame-graph/flame-graph.vue
+++ b/src/entities/profiler/ui/flame-graph/flame-graph.vue
@@ -1,8 +1,8 @@
 <script lang="ts" setup>
 import { FlameChart } from 'flame-chart-js'
 import debounce from 'lodash.debounce'
-import { ref, onMounted, nextTick, onBeforeUnmount, computed } from 'vue'
-import type { EventId } from '@/shared/types'
+import { ref, onMounted, nextTick, onBeforeUnmount, computed, watch } from 'vue'
+import { type EventId, GraphTypes } from '@/shared/types'
 import { useProfiler } from '../../lib'
 import type { CallStackHoverData, StatBoardCost } from '../../types'
 import { CallStatBoard } from '../../ui/call-stat-board'
@@ -17,8 +17,18 @@ const defaultPosition = { x: 0, y: 0 }
 
 const props = defineProps<Props>()
 
+const metric = ref<GraphTypes>(GraphTypes.WALL_TIME)
 const canvas = ref<HTMLCanvasElement>()
 const graph = ref<HTMLCanvasElement>()
+let flameChartInstance: FlameChart | null = null
+let resizeHandler: (() => void) | null = null
+
+const toolbar = [
+  { label: 'Wall time', metric: GraphTypes.WALL_TIME, description: 'Wall time in ms.' },
+  { label: 'CPU', metric: GraphTypes.CPU, description: 'CPU time in ms.' },
+  { label: 'Memory', metric: GraphTypes.MEMORY, description: 'Memory usage in bytes.' },
+  { label: 'Memory peak', metric: GraphTypes.MEMORY_CHANGE, description: 'Memory peak usage in bytes.' },
+]
 
 const activeStatBoard = ref<CallStackHoverData>()
 const activeStatBoardPosition = ref(defaultPosition)
@@ -46,20 +56,29 @@ const activeStatBoardStyle = computed(() => {
   }
 })
 
+const destroyChart = () => {
+  if (resizeHandler) {
+    window.removeEventListener('resize', resizeHandler)
+    resizeHandler = null
+  }
+  flameChartInstance = null
+}
+
 const renderChart = async () => {
   if (!graph.value || !canvas.value) {
     return
   }
+
+  destroyChart()
 
   const { width, height } = graph.value.getBoundingClientRect()
 
   canvas.value.width = width || 1
   canvas.value.height = height || 1
 
-  const flameChart = new FlameChart({
+  flameChartInstance = new FlameChart({
     canvas: canvas.value,
-    // TODO: move to api service
-    data: await getFlameChart(props.id),
+    data: await getFlameChart(props.id, { metric: metric.value }),
     settings: {
       styles: {
         main: {
@@ -85,21 +104,24 @@ const renderChart = async () => {
     }
   })
 
-  flameChart.render()
+  flameChartInstance.render()
 
-  window.addEventListener(
-    'resize',
-    debounce(() => {
-      if (!graph.value) {
-        return
-      }
+  resizeHandler = debounce(() => {
+    if (!graph.value || !flameChartInstance) {
+      return
+    }
 
-      const { width: windowWidth, height: windowHeight } = graph.value.getBoundingClientRect()
+    const { width: windowWidth, height: windowHeight } = graph.value.getBoundingClientRect()
 
-      flameChart.resize(windowWidth, windowHeight)
-    }, 30)
-  )
+    flameChartInstance.resize(windowWidth, windowHeight)
+  }, 30)
+
+  window.addEventListener('resize', resizeHandler)
 }
+
+watch(metric, () => {
+  renderChart()
+})
 
 onMounted(() => {
   nextTick(() => {
@@ -108,12 +130,28 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
+  destroyChart()
   activeStatBoard.value = undefined
 })
 </script>
 
 <template>
   <div class="graph-wrapper">
+    <div class="flame-graph__toolbar">
+      <button
+        v-for="tool in toolbar"
+        :key="tool.metric"
+        class="flame-graph__toolbar-action"
+        :class="{
+          'flame-graph__toolbar-action--active': metric === tool.metric
+        }"
+        :title="tool.description"
+        @click="metric = tool.metric"
+      >
+        {{ tool.label }}
+      </button>
+    </div>
+
     <div
       ref="graph"
       class="flame-graph"
@@ -151,5 +189,17 @@ onBeforeUnmount(() => {
 
 .profiler-page__hover-edge {
   @apply absolute z-10 h-auto;
+}
+
+.flame-graph__toolbar {
+  @apply flex bg-gray-200 p-2 rounded gap-x-5 shadow-lg mb-2;
+}
+
+.flame-graph__toolbar-action {
+  @apply text-xs uppercase text-gray-600 cursor-pointer;
+}
+
+.flame-graph__toolbar-action--active {
+  @apply font-bold;
 }
 </style>

--- a/src/shared/lib/io/use-profiler-requests.ts
+++ b/src/shared/lib/io/use-profiler-requests.ts
@@ -7,7 +7,7 @@ import { REST_API_URL } from "./constants";
 type TUseProfilerRequests = () => {
   getTopFunctions: (id: EventId, params?: Record<string, string>) => Promise<ProfilerTopFunctions>
   getCallGraph: (id: EventId, params?: Record<string, string>) => Promise<ProfilerCallGraph>
-  getFlameChart: (id: EventId) => Promise<ProfileFlameChart[]>
+  getFlameChart: (id: EventId, params?: Record<string, string>) => Promise<ProfileFlameChart[]>
 }
 
 enum ProfilerPartType {
@@ -72,7 +72,7 @@ export const useProfilerRequests: TUseProfilerRequests = () => {
     })
 
 
-  const getFlameChart = (id: EventId) => fetch(getProfilerPartsRestUrl({ id, type: ProfilerPartType.FlameChart }), { headers })
+  const getFlameChart = (id: EventId, params?: Record<string, string>) => fetch(getProfilerPartsRestUrl({ id, params, type: ProfilerPartType.FlameChart }), { headers })
     .then((response) => response.json())
     .then((response) => {
       if (response) {


### PR DESCRIPTION
## Summary

- Add metric toolbar (Wall time, CPU, Memory, Memory peak) to the flame graph component, matching the call graph toolbar UX
- Pass selected metric as query param (`?metric=wt|cpu|mu|pmu`) to the backend `/api/profiler/{id}/flame-chart` endpoint
- Fix memory leak: destroy old `FlameChart` instance and remove resize event listener before re-rendering on metric switch
- Properly clean up on component unmount

Companion backend PR: buggregator/server#312

## Test plan

- [x] Verify flame chart renders with default Wall time metric
- [x] Switch between all 4 metrics and verify chart re-renders with correct data
- [x] Verify no console errors on metric switch or component unmount
- [x] Verify resize still works after metric switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)