### PR TITLE
Enhance profiler flame chart and unify design

### DIFF
--- a/src/entities/profiler/ui/call-graph/call-graph.vue
+++ b/src/entities/profiler/ui/call-graph/call-graph.vue
@@ -374,7 +374,7 @@ const currentMetricKey = computed(() => {
 
 <style lang="scss" scoped>
 .call-graph {
-  @apply relative flex rounded min-h-min min-w-min h-full bg-white -mt-3 pt-3 dark:bg-gray-800;
+  @apply relative flex h-full bg-gray-50 dark:bg-gray-800 overflow-hidden;
 }
 
 .call-graph__graph {
@@ -390,11 +390,11 @@ const currentMetricKey = computed(() => {
 }
 
 .call-graph__toolbar {
-  @apply absolute top-5 left-5 flex items-center bg-gray-200 dark:bg-gray-700 p-2 rounded gap-x-3 shadow-lg z-10;
+  @apply absolute top-3 left-3 flex items-center backdrop-blur-sm bg-white/80 dark:bg-gray-800/80 p-2 rounded-md gap-x-3 shadow-md border border-gray-200/50 dark:border-gray-600/50 z-10;
 }
 
 .call-graph__toolbar--right {
-  @apply right-5 left-auto py-1;
+  @apply right-3 left-auto py-1;
 }
 
 .call-graph__toolbar-icon {
@@ -435,7 +435,7 @@ const currentMetricKey = computed(() => {
 
 /* Search */
 .call-graph__search {
-  @apply absolute top-16 left-5 z-20 w-80;
+  @apply absolute top-14 left-3 z-20 w-80;
 }
 
 .call-graph__search-input {

--- a/src/entities/profiler/ui/flame-graph/flame-graph.vue
+++ b/src/entities/profiler/ui/flame-graph/flame-graph.vue
@@ -2,34 +2,49 @@
 import { FlameChart } from 'flame-chart-js'
 import debounce from 'lodash.debounce'
 import { ref, onMounted, nextTick, onBeforeUnmount, computed, watch } from 'vue'
+import { useFormats } from '@/shared/lib/formats'
 import { type EventId, GraphTypes } from '@/shared/types'
 import { useProfiler } from '../../lib'
-import type { CallStackHoverData, StatBoardCost } from '../../types'
+import type { CallStackHoverData, ProfileFlameChart, StatBoardCost } from '../../types'
 import { CallStatBoard } from '../../ui/call-stat-board'
 
 type Props = {
   id: EventId
 }
 
-const { getFlameChart } = useProfiler()
+type SandwichEntry = {
+  name: string
+  totalCost: Record<string, number>
+  count: number
+}
 
+const { getFlameChart } = useProfiler()
+const { formatDuration, formatFileSize } = useFormats()
+
+const isDark = () => document.documentElement.classList.contains('dark')
 const defaultPosition = { x: 0, y: 0 }
 
 const props = defineProps<Props>()
 
 const metric = ref<GraphTypes>(GraphTypes.WALL_TIME)
 const canvas = ref<HTMLCanvasElement>()
-const graph = ref<HTMLCanvasElement>()
+const graph = ref<HTMLElement>()
 let flameChartInstance: FlameChart | null = null
 let resizeHandler: (() => void) | null = null
+let flameData: ProfileFlameChart[] = []
 
 const toolbar = [
   { label: 'Wall time', metric: GraphTypes.WALL_TIME, description: 'Wall time in ms.' },
   { label: 'CPU', metric: GraphTypes.CPU, description: 'CPU time in ms.' },
   { label: 'Memory', metric: GraphTypes.MEMORY, description: 'Memory usage in bytes.' },
-  { label: 'Memory peak', metric: GraphTypes.MEMORY_CHANGE, description: 'Memory peak usage in bytes.' },
+  {
+    label: 'Memory peak',
+    metric: GraphTypes.MEMORY_CHANGE,
+    description: 'Memory peak usage in bytes.'
+  }
 ]
 
+// --- Tooltip ---
 const activeStatBoard = ref<CallStackHoverData>()
 const activeStatBoardPosition = ref(defaultPosition)
 
@@ -56,12 +71,183 @@ const activeStatBoardStyle = computed(() => {
   }
 })
 
+// --- Search ---
+const searchQuery = ref('')
+const searchResults = ref<Array<{ name: string; count: number }>>([])
+const searchFocused = ref(false)
+
+function collectFunctionNames(nodes: ProfileFlameChart[]): Map<string, number> {
+  const names = new Map<string, number>()
+
+  function walk(node: ProfileFlameChart) {
+    const count = names.get(node.name) || 0
+    names.set(node.name, count + 1)
+    for (const child of node.children || []) {
+      walk(child)
+    }
+  }
+
+  for (const root of nodes) {
+    walk(root)
+  }
+  return names
+}
+
+function onSearchInput() {
+  if (!searchQuery.value.trim()) {
+    searchResults.value = []
+    return
+  }
+
+  const q = searchQuery.value.toLowerCase()
+  const names = collectFunctionNames(flameData)
+  searchResults.value = Array.from(names.entries())
+    .filter(([name]) => name.toLowerCase().includes(q))
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 15)
+}
+
+function onSearchSelect(name: string) {
+  searchQuery.value = ''
+  searchResults.value = []
+  searchFocused.value = false
+  openSandwich(name)
+}
+
+function onSearchSubmit() {
+  if (searchResults.value.length > 0) {
+    onSearchSelect(searchResults.value[0].name)
+  }
+}
+
+function onSearchBlur() {
+  setTimeout(() => {
+    searchFocused.value = false
+    searchResults.value = []
+  }, 200)
+}
+
+// --- Sandwich view ---
+const sandwichOpen = ref(false)
+const sandwichCallers = ref<SandwichEntry[]>([])
+const sandwichCallees = ref<SandwichEntry[]>([])
+const sandwichSelf = ref<SandwichEntry | null>(null)
+
+function buildSandwich(
+  nodes: ProfileFlameChart[],
+  targetName: string
+): { callers: SandwichEntry[]; callees: SandwichEntry[]; self: SandwichEntry } {
+  const callersMap = new Map<string, { cost: Record<string, number>; count: number }>()
+  const calleesMap = new Map<string, { cost: Record<string, number>; count: number }>()
+  const selfCost: Record<string, number> = {}
+  let selfCount = 0
+
+  function walk(node: ProfileFlameChart, parent: ProfileFlameChart | null) {
+    if (node.name === targetName) {
+      selfCount++
+      for (const [k, v] of Object.entries(node.cost || {})) {
+        selfCost[k] = (selfCost[k] || 0) + (v as number)
+      }
+
+      if (parent) {
+        const existing = callersMap.get(parent.name)
+        if (existing) {
+          existing.count++
+          for (const [k, v] of Object.entries(parent.cost || {})) {
+            existing.cost[k] = (existing.cost[k] || 0) + (v as number)
+          }
+        } else {
+          callersMap.set(parent.name, {
+            cost: { ...(parent.cost || {}) } as Record<string, number>,
+            count: 1
+          })
+        }
+      }
+
+      for (const child of node.children || []) {
+        const existing = calleesMap.get(child.name)
+        if (existing) {
+          existing.count++
+          for (const [k, v] of Object.entries(child.cost || {})) {
+            existing.cost[k] = (existing.cost[k] || 0) + (v as number)
+          }
+        } else {
+          calleesMap.set(child.name, {
+            cost: { ...(child.cost || {}) } as Record<string, number>,
+            count: 1
+          })
+        }
+      }
+    }
+
+    for (const child of node.children || []) {
+      walk(child, node)
+    }
+  }
+
+  for (const root of nodes) {
+    walk(root, null)
+  }
+
+  const toEntries = (
+    map: Map<string, { cost: Record<string, number>; count: number }>
+  ): SandwichEntry[] =>
+    Array.from(map.entries())
+      .map(([name, { cost, count }]) => ({ name, totalCost: cost, count }))
+      .sort((a, b) => (b.totalCost.wt || 0) - (a.totalCost.wt || 0))
+
+  return {
+    callers: toEntries(callersMap),
+    callees: toEntries(calleesMap),
+    self: { name: targetName, totalCost: selfCost, count: selfCount }
+  }
+}
+
+function openSandwich(name: string) {
+  const result = buildSandwich(flameData, name)
+  sandwichCallers.value = result.callers
+  sandwichCallees.value = result.callees
+  sandwichSelf.value = result.self
+  sandwichOpen.value = true
+}
+
+function closeSandwich() {
+  sandwichOpen.value = false
+  sandwichCallers.value = []
+  sandwichCallees.value = []
+  sandwichSelf.value = null
+}
+
+function formatCostValue(key: string, value: number): string {
+  if (key === 'ct') return String(value)
+  if (key === 'mu' || key === 'pmu') return formatFileSize(value, 3) || '0'
+  return formatDuration(value) || '0'
+}
+
+const currentMetricKey = computed(() => {
+  const map: Record<string, string> = {
+    [GraphTypes.CPU]: 'cpu',
+    [GraphTypes.WALL_TIME]: 'wt',
+    [GraphTypes.MEMORY]: 'mu',
+    [GraphTypes.MEMORY_CHANGE]: 'pmu',
+    [GraphTypes.CALLS]: 'ct'
+  }
+  return map[metric.value] || 'wt'
+})
+
+// --- Chart rendering ---
+
 const destroyChart = () => {
   if (resizeHandler) {
     window.removeEventListener('resize', resizeHandler)
     resizeHandler = null
   }
-  flameChartInstance = null
+  if (flameChartInstance) {
+    flameChartInstance.interactionsEngine.destroy()
+    flameChartInstance.removeAllListeners()
+    flameChartInstance = null
+  }
 }
 
 const renderChart = async () => {
@@ -76,13 +262,36 @@ const renderChart = async () => {
   canvas.value.width = width || 1
   canvas.value.height = height || 1
 
+  const ctx = canvas.value.getContext('2d')
+  if (ctx) {
+    ctx.clearRect(0, 0, canvas.value.width, canvas.value.height)
+  }
+
+  flameData = await getFlameChart(props.id, { metric: metric.value })
+
   flameChartInstance = new FlameChart({
     canvas: canvas.value,
-    data: await getFlameChart(props.id, { metric: metric.value }),
+    data: flameData,
     settings: {
       styles: {
         main: {
-          blockHeight: 20
+          blockHeight: 20,
+          blockPaddingLeftRight: 4,
+          backgroundColor: isDark() ? '#1f2937' : '#f9fafb',
+          headerHeight: 0
+        },
+        timeGridPlugin: {
+          fontColor: isDark() ? '#9ca3af' : '#6b7280'
+        },
+        timeframeSelectorPlugin: {
+          backgroundColor: isDark() ? '#111827' : '#f3f4f6',
+          fontColor: isDark() ? '#e5e7eb' : '#374151',
+          graphStrokeColor: isDark() ? '#60a5fa' : '#93c5fd',
+          graphFillColor: isDark() ? 'rgba(96,165,250,0.15)' : 'rgba(147,197,253,0.25)',
+          bottomLineColor: isDark() ? '#374151' : '#d1d5db',
+          knobColor: isDark() ? '#60a5fa' : '#3b82f6',
+          knobStrokeColor: isDark() ? '#93c5fd' : '#2563eb',
+          overlayColor: isDark() ? 'rgba(0,0,0,0.5)' : 'rgba(0,0,0,0.2)'
         }
       },
       options: {
@@ -106,14 +315,19 @@ const renderChart = async () => {
 
   flameChartInstance.render()
 
+  flameChartInstance.on('select', (data: unknown) => {
+    const d = data as { type?: string; node?: { source?: { name?: string } } } | null
+    if (d?.node?.source?.name) {
+      openSandwich(d.node.source.name)
+    }
+  })
+
   resizeHandler = debounce(() => {
     if (!graph.value || !flameChartInstance) {
       return
     }
-
-    const { width: windowWidth, height: windowHeight } = graph.value.getBoundingClientRect()
-
-    flameChartInstance.resize(windowWidth, windowHeight)
+    const { width: w, height: h } = graph.value.getBoundingClientRect()
+    flameChartInstance.resize(w, h)
   }, 30)
 
   window.addEventListener('resize', resizeHandler)
@@ -136,35 +350,162 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div class="graph-wrapper">
-    <div class="flame-graph__toolbar">
+  <div class="flame-wrapper">
+    <!-- Toolbar (above canvas) -->
+    <div class="flame-toolbar">
       <button
         v-for="tool in toolbar"
         :key="tool.metric"
-        class="flame-graph__toolbar-action"
-        :class="{
-          'flame-graph__toolbar-action--active': metric === tool.metric
-        }"
+        class="flame-toolbar__action"
+        :class="{ 'flame-toolbar__action--active': metric === tool.metric }"
         :title="tool.description"
         @click="metric = tool.metric"
       >
         {{ tool.label }}
       </button>
+
+      <span class="flame-toolbar__separator" />
+
+      <!-- Inline search -->
+      <div class="flame-toolbar__search-wrap">
+        <input
+          v-model="searchQuery"
+          class="flame-toolbar__search"
+          type="text"
+          placeholder="Search function..."
+          @input="onSearchInput"
+          @keydown.enter="onSearchSubmit"
+          @focus="searchFocused = true"
+          @blur="onSearchBlur"
+        >
+        <div
+          v-if="searchFocused && searchResults.length"
+          class="flame-toolbar__search-dropdown"
+        >
+          <button
+            v-for="item in searchResults"
+            :key="item.name"
+            class="flame-toolbar__search-item"
+            @mousedown.prevent="onSearchSelect(item.name)"
+          >
+            <span class="flame-toolbar__search-item-name">{{ item.name }}</span>
+            <span class="flame-toolbar__search-item-count">{{ item.count }}x</span>
+          </button>
+        </div>
+      </div>
     </div>
 
-    <div
-      ref="graph"
-      class="flame-graph"
-    >
-      <canvas
-        ref="canvas"
-        class="flame-graph__canvas"
-      />
+    <!-- Canvas + sidebar -->
+    <div class="flame-content">
+      <div
+        ref="graph"
+        class="flame-canvas-wrap"
+      >
+        <canvas
+          ref="canvas"
+          class="flame-canvas"
+        />
+      </div>
+
+      <!-- Sandwich sidebar -->
+      <transition name="sidebar">
+        <div
+          v-if="sandwichOpen && sandwichSelf"
+          class="flame-sidebar"
+        >
+          <div class="flame-sidebar__header">
+            <h3 class="flame-sidebar__title">
+              Sandwich View
+            </h3>
+            <button
+              class="flame-sidebar__close"
+              @click="closeSandwich"
+            >
+              &times;
+            </button>
+          </div>
+
+          <div class="flame-sidebar__body">
+            <!-- Self -->
+            <div class="flame-sandwich__section">
+              <div class="flame-sandwich__self">
+                <div class="flame-sandwich__fn-name">
+                  {{ sandwichSelf.name }}
+                </div>
+                <div class="flame-sandwich__fn-meta">
+                  <span class="flame-sandwich__fn-cost">
+                    {{
+                      formatCostValue(
+                        currentMetricKey,
+                        sandwichSelf.totalCost[currentMetricKey] || 0
+                      )
+                    }}
+                  </span>
+                  <span class="flame-sandwich__fn-count"> {{ sandwichSelf.count }}x calls </span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Callers -->
+            <div
+              v-if="sandwichCallers.length"
+              class="flame-sandwich__section"
+            >
+              <h4 class="flame-sandwich__label">
+                Called by
+              </h4>
+              <div
+                v-for="entry in sandwichCallers"
+                :key="'caller-' + entry.name"
+                class="flame-sandwich__entry"
+                @click="openSandwich(entry.name)"
+              >
+                <div class="flame-sandwich__entry-name">
+                  {{ entry.name }}
+                </div>
+                <div class="flame-sandwich__entry-meta">
+                  <span>{{
+                    formatCostValue(currentMetricKey, entry.totalCost[currentMetricKey] || 0)
+                  }}</span>
+                  <span class="flame-sandwich__entry-count">{{ entry.count }}x</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Callees -->
+            <div
+              v-if="sandwichCallees.length"
+              class="flame-sandwich__section"
+            >
+              <h4 class="flame-sandwich__label">
+                Calls
+              </h4>
+              <div
+                v-for="entry in sandwichCallees"
+                :key="'callee-' + entry.name"
+                class="flame-sandwich__entry"
+                @click="openSandwich(entry.name)"
+              >
+                <div class="flame-sandwich__entry-name">
+                  {{ entry.name }}
+                </div>
+                <div class="flame-sandwich__entry-meta">
+                  <span>{{
+                    formatCostValue(currentMetricKey, entry.totalCost[currentMetricKey] || 0)
+                  }}</span>
+                  <span class="flame-sandwich__entry-count">{{ entry.count }}x</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </transition>
     </div>
 
+    <!-- Tooltip -->
     <CallStatBoard
       v-if="activeStatBoard?.cost"
-      class="profiler-page__hover-edge"
+      class="flame-tooltip"
       :title="activeStatBoard.title || ''"
       :cost="activeStatBoard.cost as StatBoardCost"
       :style="activeStatBoardStyle"
@@ -173,33 +514,147 @@ onBeforeUnmount(() => {
 </template>
 
 <style lang="scss" scoped>
-.graph-wrapper {
-  @apply mb-5;
+.flame-wrapper {
+  @apply relative flex flex-col h-full bg-gray-50 dark:bg-gray-800 overflow-hidden;
 }
 
-.flame-graph {
-  @apply w-full h-full relative min-h-[500px];
-  @apply bg-white;
-  @apply rounded-md mt-2 overflow-hidden;
+/* Toolbar (in flow, above canvas) */
+.flame-toolbar {
+  @apply flex items-center backdrop-blur-sm bg-white/80 dark:bg-gray-800/80 px-3 py-2 gap-x-3 flex-shrink-0 border-b border-gray-200/50 dark:border-gray-600/50;
 }
 
-.flame-graph__canvas {
-  @apply w-full h-full bg-white pt-3;
+/* Content: canvas + sidebar */
+.flame-content {
+  @apply flex flex-1 min-h-0 relative;
 }
 
-.profiler-page__hover-edge {
-  @apply absolute z-10 h-auto;
+.flame-canvas-wrap {
+  @apply flex-1 overflow-hidden;
 }
 
-.flame-graph__toolbar {
-  @apply flex bg-gray-200 p-2 rounded gap-x-5 shadow-lg mb-2;
+.flame-canvas {
+  @apply w-full h-full;
 }
 
-.flame-graph__toolbar-action {
-  @apply text-xs uppercase text-gray-600 cursor-pointer;
+.flame-toolbar__action {
+  @apply text-xs uppercase text-gray-600 dark:text-gray-300 cursor-pointer px-2 py-1 rounded hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors whitespace-nowrap;
 }
 
-.flame-graph__toolbar-action--active {
+.flame-toolbar__action--active {
   @apply font-bold;
+}
+
+.flame-toolbar__separator {
+  @apply w-px h-5 bg-gray-400 flex-shrink-0;
+}
+
+.flame-toolbar__search-wrap {
+  @apply relative min-w-[180px] max-w-[280px];
+}
+
+.flame-toolbar__search {
+  @apply w-full px-3 py-1 text-xs bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 border border-gray-300 dark:border-gray-500 rounded outline-none;
+  @apply focus:ring-1 focus:ring-blue-400 focus:border-blue-400;
+}
+
+.flame-toolbar__search-dropdown {
+  @apply absolute top-full left-0 right-0 mt-1 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded shadow-lg max-h-60 overflow-y-auto z-30;
+}
+
+.flame-toolbar__search-item {
+  @apply flex justify-between items-center w-full px-3 py-2 text-xs text-left hover:bg-blue-50 dark:hover:bg-gray-600 transition-colors;
+}
+
+.flame-toolbar__search-item-name {
+  @apply text-gray-800 dark:text-gray-200 truncate mr-2;
+}
+
+.flame-toolbar__search-item-count {
+  @apply text-gray-500 dark:text-gray-400 font-mono whitespace-nowrap;
+}
+
+/* Tooltip */
+.flame-tooltip {
+  @apply absolute z-10 h-auto pointer-events-none;
+}
+
+/* Sidebar */
+.flame-sidebar {
+  @apply w-[320px] flex-shrink-0 bg-white dark:bg-gray-900 border-l border-gray-200 dark:border-gray-700 shadow-xl flex flex-col overflow-hidden;
+}
+
+.flame-sidebar__header {
+  @apply flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-700 flex-shrink-0;
+}
+
+.flame-sidebar__title {
+  @apply text-sm font-bold text-gray-800 dark:text-gray-200 uppercase tracking-wide;
+}
+
+.flame-sidebar__close {
+  @apply text-xl text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 leading-none px-1;
+}
+
+.flame-sidebar__body {
+  @apply flex-1 overflow-y-auto;
+}
+
+/* Sandwich */
+.flame-sandwich__section {
+  @apply border-b border-gray-200 dark:border-gray-700 px-4 py-3;
+}
+
+.flame-sandwich__self {
+  @apply bg-blue-50 dark:bg-blue-900/30 rounded p-3;
+}
+
+.flame-sandwich__fn-name {
+  @apply text-xs font-semibold text-gray-800 dark:text-gray-200 break-words leading-tight;
+}
+
+.flame-sandwich__fn-meta {
+  @apply flex items-center gap-3 mt-2;
+}
+
+.flame-sandwich__fn-cost {
+  @apply text-sm font-bold text-gray-700 dark:text-gray-300 font-mono;
+}
+
+.flame-sandwich__fn-count {
+  @apply text-xs text-gray-500 dark:text-gray-400;
+}
+
+.flame-sandwich__label {
+  @apply text-[10px] font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2;
+}
+
+.flame-sandwich__entry {
+  @apply py-2 px-2 -mx-2 rounded cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors;
+}
+
+.flame-sandwich__entry-name {
+  @apply text-xs text-gray-700 dark:text-gray-300 break-words leading-tight;
+}
+
+.flame-sandwich__entry-meta {
+  @apply flex items-center gap-2 mt-1 text-[11px] font-mono text-gray-500 dark:text-gray-400;
+}
+
+.flame-sandwich__entry-count {
+  @apply text-[10px] text-gray-400;
+}
+
+/* Transitions */
+.sidebar-enter-active,
+.sidebar-leave-active {
+  transition:
+    transform 0.25s ease,
+    opacity 0.25s ease;
+}
+
+.sidebar-enter-from,
+.sidebar-leave-to {
+  transform: translateX(100%);
+  opacity: 0;
 }
 </style>

--- a/src/entities/profiler/ui/profiler-page/profiler-page.vue
+++ b/src/entities/profiler/ui/profiler-page/profiler-page.vue
@@ -68,30 +68,22 @@ const tabChange = (selectedTab: { tab: { name: string } }) => {
 
 <style lang="scss" scoped>
 .profiler-page {
-  @apply relative h-full;
+  @apply relative h-full overflow-hidden;
 }
 
 .profiler-page__main {
-  @apply flex flex-col md:flex-row h-full;
-}
-
-.profiler-page__callstack {
-  @apply w-full md:w-[250px] border-r border-gray-300 dark:border-gray-500;
+  @apply flex flex-col h-full;
 }
 
 .profiler-page__stat {
-  @apply w-full flex flex-col;
-}
-
-.profiler-page__stat-board {
-  @apply bg-gray-200 dark:bg-gray-800;
+  @apply w-full flex flex-col h-full overflow-hidden;
 }
 
 .profiler-page__stat-tabs {
-  @apply bg-gray-200 flex-1 flex flex-col dark:bg-gray-800 dark:text-gray-300;
+  @apply bg-gray-50 dark:bg-gray-800 dark:text-gray-300 flex-1 flex flex-col overflow-hidden;
 }
 
-.profiler-page__stat-tabs .tabs-component-panel {
-  @apply h-full;
+.profiler-page__stat-tabs :deep(.tabs-component-panel) {
+  @apply flex-1 overflow-hidden;
 }
 </style>

--- a/src/entities/profiler/ui/top-functions/top-functions.vue
+++ b/src/entities/profiler/ui/top-functions/top-functions.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-// TODO: need to create storybook test for this component
 import { ref, watchEffect } from 'vue'
 import { formatDuration } from '@/shared/lib/formats/format-duration'
 import { formatFileSize } from '@/shared/lib/formats/format-file-size'
@@ -14,7 +13,7 @@ type Props = {
 
 const { getTopFunctions } = useProfiler()
 const props = defineProps<Props>()
-const metric = ref('excl_wt') // TODO: use enum value
+const metric = ref('excl_wt')
 
 const data = ref<ProfilerTopFunctions>({
   functions: [],
@@ -60,98 +59,134 @@ watchEffect(async () => {
 </script>
 
 <template>
-  <section class="top-functions__stat-board">
-    <StatBoard
-      v-if="data.overall_totals"
-      :cost="data.overall_totals"
-    />
-  </section>
+  <div class="top-fn">
+    <!-- Stat board -->
+    <div class="top-fn__stat">
+      <StatBoard
+        v-if="data.overall_totals"
+        :cost="data.overall_totals"
+      />
+    </div>
 
-  <div class="top-functions__body">
-    <table class="top-functions__table">
-      <thead>
-        <tr>
-          <td
-            v-for="col in data.schema"
-            :key="col.key"
-            class="text-left"
-            :class="`col-${col.key} ${metric === col.key ? 'selected' : ''}`"
-            :title="col.description"
-            @click="setMetric(col.sortable ? col.key : undefined)"
-          >
-            {{ col.label }}
-          </td>
-        </tr>
-      </thead>
-
-      <tbody>
-        <tr
-          v-for="item in data.functions"
-          :key="item.function"
-        >
-          <td
-            v-for="col in data.schema"
-            :key="col.key"
-            class="text-left"
-            :class="`col-${col.key} ${metric === col.key ? 'selected' : ''}`"
-          >
-            <div
-              v-for="value in col.values"
-              :key="value.key"
-              class="table-value"
-              :class="`value-${value.format}`"
+    <!-- Table -->
+    <div class="top-fn__table-wrap">
+      <table class="top-fn__table">
+        <thead>
+          <tr>
+            <td
+              v-for="col in data.schema"
+              :key="col.key"
+              class="top-fn__th"
+              :class="{
+                'top-fn__th--sortable': col.sortable,
+                'top-fn__th--active': metric === col.key
+              }"
+              :title="col.description"
+              @click="setMetric(col.sortable ? col.key : undefined)"
             >
-              {{ formatValue(item[value.key], value.format) }}
-            </div>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+              {{ col.label }}
+            </td>
+          </tr>
+        </thead>
+
+        <tbody>
+          <tr
+            v-for="item in data.functions"
+            :key="item.function"
+            class="top-fn__row"
+          >
+            <td
+              v-for="col in data.schema"
+              :key="col.key"
+              class="top-fn__td"
+              :class="{
+                'top-fn__td--active': metric === col.key,
+                'top-fn__td--fn': col.key === 'function'
+              }"
+            >
+              <div
+                v-for="value in col.values"
+                :key="value.key"
+                :class="{
+                  'top-fn__value': true,
+                  'top-fn__value--sub': value.format === 'percent'
+                }"
+              >
+                {{ formatValue(item[value.key], value.format) }}
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
 </template>
 
 <style scoped lang="scss">
-@use 'src/assets/mixins' as mixins;
-
-.top-functions__body {
-  @include mixins.border-style;
-  @apply overflow-auto mb-5 mt-2 rounded-md;
+.top-fn {
+  @apply flex flex-col h-full bg-gray-50 dark:bg-gray-800 overflow-hidden;
 }
 
-.top-functions__table {
-  @apply w-full overflow-auto;
+.top-fn__stat {
+  @apply flex-shrink-0 border-b border-gray-200 dark:border-gray-700;
 }
 
-table {
+.top-fn__table-wrap {
+  @apply flex-1 overflow-auto;
+}
+
+.top-fn__table {
   @apply w-full text-xs;
 }
 
-table thead {
-  @apply bg-gray-300 dark:bg-gray-900 text-base;
+/* Header */
+thead {
+  @apply backdrop-blur-sm bg-white/90 dark:bg-gray-900/90 sticky top-0 z-10 border-b border-gray-200/50 dark:border-gray-600/50;
 }
 
-td {
-  @apply px-4;
+.top-fn__th {
+  @apply px-4 py-2.5 text-left text-[11px] font-bold uppercase tracking-wide text-gray-500 dark:text-gray-400 whitespace-nowrap;
 }
 
-td.selected {
-  @apply border-x text-gray-800 dark:text-gray-100 border-gray-400 dark:border-gray-500;
+.top-fn__th--sortable {
+  @apply cursor-pointer hover:text-gray-700 dark:hover:text-gray-200 transition-colors;
 }
 
-thead td {
-  @apply font-black py-3 text-gray-500 dark:text-gray-400 cursor-pointer;
-  @apply py-2;
+.top-fn__th--active {
+  @apply text-gray-800 dark:text-gray-100 border-x border-gray-300 dark:border-gray-600 bg-gray-200/50 dark:bg-gray-800/50;
 }
 
-tbody tr {
-  @apply dark:hover:bg-gray-900;
+/* Rows */
+.top-fn__row {
+  @apply hover:bg-blue-50 dark:hover:bg-gray-700/50 transition-colors;
 
   &:nth-child(odd) {
-    @apply dark:bg-gray-700 bg-gray-100;
+    @apply bg-gray-100 dark:bg-gray-700;
+  }
+
+  &:nth-child(even) {
+    @apply bg-white dark:bg-gray-800;
   }
 }
 
-.table-value.value-percent {
-  @apply text-xs text-gray-500;
+.top-fn__td {
+  @apply px-4 py-1.5 text-left;
+}
+
+.top-fn__td--active {
+  @apply border-x border-gray-200 dark:border-gray-600 bg-gray-100/30 dark:bg-gray-700/20;
+}
+
+.top-fn__td--fn {
+  @apply font-medium text-gray-800 dark:text-gray-200 max-w-[400px] truncate;
+}
+
+/* Values */
+.top-fn__value {
+  @apply text-gray-700 dark:text-gray-300;
+}
+
+.top-fn__value--sub {
+  @apply text-[10px] text-gray-400 dark:text-gray-500;
 }
 </style>


### PR DESCRIPTION
## Summary
- **Flame chart: search** — inline search input in toolbar with autocomplete dropdown, finds functions by name across the tree
- **Flame chart: sandwich view** — click any block to see all callers and callees of that function aggregated in a sidebar
- **Flame chart: bug fix** — properly destroy old FlameChart instances on metric switch (was causing visual glitches from stale event listeners)
- **Flame chart: theming** — dark-mode-aware colors for canvas, timeline, graph peaks, knobs, and text; removed duplicate time header; increased block padding to prevent text overlap
- **Design unification** — all three profiler tabs (Call graph, Flamechart, Top functions) now share consistent styling:
  - Background: `bg-gray-50 dark:bg-gray-800` (matches site default)
  - Frosted glass toolbars (`backdrop-blur-sm`, semi-transparent)
  - Overflow-hidden cascade from profiler page through tab panels
  - Top functions: sticky frosted header, zebra rows with contrast, hover states

<img width="1401" height="887" alt="image" src="https://github.com/user-attachments/assets/d7748f7b-f525-447e-ac0d-cc46d2f312ab" />

## Test plan
- [x] Open profiler page, switch between all three tabs — no scroll leaks
- [x] Flamechart: switch metrics (Wall time → CPU → Memory) — no visual glitches on hover
- [x] Flamechart: type in search, verify autocomplete shows functions with call counts
- [x] Flamechart: click a block — sandwich sidebar opens with callers/callees
- [x] Flamechart: click caller/callee in sidebar — navigates to that function's sandwich
- [x] Verify dark mode colors on timeline (light text, blue peaks, themed knobs)
- [x] Call graph: verify frosted glass toolbar style
- [x] Top functions: verify sticky header, zebra rows, active column highlight
- [x] Test fullscreen mode in call graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)