### PR TITLE
Add search, event list perf, and preview card improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "tailwindcss": "^3.2.4",
     "vue": "^3.4.29",
     "vue-router": "^4.3.3",
+    "vue-virtual-scroller": "^2.0.0-beta.10",
     "vue3-tabs-component": "^1.2.0"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"

--- a/src/assets/symfony-var-dump.css
+++ b/src/assets/symfony-var-dump.css
@@ -112,8 +112,8 @@ pre.sf-dump .sf-dump-toolbar {
   align-items: center;
   justify-content: space-between;
   gap: 4px;
-  padding: 3px 6px;
-  margin-bottom: 4px;
+  padding: 0 6px;
+  margin-bottom: 0;
   background: #141720;
   border: 1px solid #2a2f3a;
   border-radius: 5px;
@@ -121,6 +121,22 @@ pre.sf-dump .sf-dump-toolbar {
   position: sticky;
   top: 0;
   z-index: 20;
+  max-height: 0;
+  overflow: hidden;
+  opacity: 0;
+  transition:
+    max-height 0.2s ease,
+    opacity 0.15s ease,
+    padding 0.2s ease,
+    margin-bottom 0.2s ease;
+}
+
+pre.sf-dump:hover .sf-dump-toolbar,
+pre.sf-dump:focus-within .sf-dump-toolbar {
+  max-height: 40px;
+  padding: 3px 6px;
+  margin-bottom: 8px;
+  opacity: 1;
 }
 
 pre.sf-dump .sf-dump-toolbar-group {

--- a/src/entities/monolog/ui/preview-card/preview-card.vue
+++ b/src/entities/monolog/ui/preview-card/preview-card.vue
@@ -26,43 +26,82 @@ const isFullMessage = ref(message.value.length === shortMessage.value.length)
 const toggleView = () => {
   isFullMessage.value = !isFullMessage.value
 }
+
+const hasContext = computed(() => {
+  const ctx = props.event.payload.context
+  if (!ctx) return false
+  const keys = Object.keys(ctx).filter((k) => k !== 'source')
+  return keys.length > 0
+})
+
+const hasExtra = computed(() => {
+  const extra = props.event.payload.extra
+  if (!extra) return false
+  if (Array.isArray(extra)) return extra.length > 0
+  return Object.keys(extra).length > 0
+})
 </script>
 
 <template>
   <PreviewCard :event="event">
     <div class="monolog-body">
-      <CodeSnippet
-        class="monolog-body__snippet"
-        :class="{ 'monolog-body__snippet--clickable': !isFullMessage }"
-        :code="isFullMessage ? message : shortMessage"
-        title="Click to show full message"
-        @click="toggleView"
-      />
+      <div class="monolog-block">
+        <CodeSnippet
+          :class="{ 'monolog-body__snippet--clickable': !isFullMessage }"
+          :code="isFullMessage ? message : shortMessage"
+          title="Click to show full message"
+          @click="toggleView"
+        />
+      </div>
 
-      <CodeSnippet
-        v-if="event.payload.context"
-        class="monolog-body__snippet"
-        language="json"
-        :code="event.payload.context"
-      />
+      <div
+        v-if="hasContext"
+        class="monolog-block"
+      >
+        <div class="monolog-block__header">
+          context
+        </div>
+        <CodeSnippet
+          language="json"
+          :code="event.payload.context"
+        />
+      </div>
 
-      <CodeSnippet
-        v-if="event.payload.extra"
-        class="monolog-body__snippet"
-        language="json"
-        :code="event.payload.extra"
-      />
+      <div
+        v-if="hasExtra"
+        class="monolog-block"
+      >
+        <div class="monolog-block__header">
+          extra
+        </div>
+        <CodeSnippet
+          language="json"
+          :code="event.payload.extra"
+        />
+      </div>
     </div>
   </PreviewCard>
 </template>
 
 <style lang="scss" scoped>
 .monolog-body {
-  @apply flex flex-col gap-1 text-xs;
+  @apply flex flex-col gap-1.5 text-xs;
 }
 
-.monolog-body__snippet {
-  @apply break-words;
+.monolog-block {
+  @apply rounded overflow-hidden;
+  @apply border border-gray-200 dark:border-gray-700;
+
+  :deep(.code-snippet) {
+    @apply rounded-none;
+  }
+}
+
+.monolog-block__header {
+  @apply flex items-center px-3 py-1.5;
+  @apply bg-gray-50 dark:bg-gray-900;
+  @apply border-b border-gray-200 dark:border-gray-700;
+  @apply text-2xs font-medium text-gray-500 dark:text-gray-400;
 }
 
 .monolog-body__snippet--clickable {

--- a/src/entities/smtp/ui/preview-card/preview-card.vue
+++ b/src/entities/smtp/ui/preview-card/preview-card.vue
@@ -49,21 +49,38 @@ const hasHtml = computed(() => !!props.event?.payload?.html)
         >HTML</span>
       </div>
 
-      <div class="smtp-body__addresses">
+      <div
+        v-if="emailFrom || emailTo"
+        class="smtp-body__flow"
+      >
         <span
           v-if="emailFrom"
-          class="smtp-body__addr"
+          class="smtp-body__pill"
+        >{{ emailFrom }}</span>
+
+        <svg
+          v-if="emailFrom && emailTo"
+          class="smtp-body__arrow"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
         >
-          <span class="smtp-body__addr-label">From</span>
-          {{ emailFrom }}
-        </span>
+          <line
+            x1="5"
+            y1="12"
+            x2="19"
+            y2="12"
+          />
+          <polyline points="12 5 19 12 12 19" />
+        </svg>
+
         <span
           v-if="emailTo"
-          class="smtp-body__addr"
-        >
-          <span class="smtp-body__addr-label">To</span>
-          {{ emailTo }}
-        </span>
+          class="smtp-body__pill"
+        >{{ emailTo }}</span>
       </div>
 
       <p
@@ -97,16 +114,20 @@ const hasHtml = computed(() => !!props.event?.payload?.html)
   @apply bg-amber-100 dark:bg-amber-500/15 text-amber-700 dark:text-amber-400;
 }
 
-.smtp-body__addresses {
-  @apply flex flex-wrap gap-x-4 gap-y-0.5 text-xs mb-1.5;
+.smtp-body__flow {
+  @apply flex items-center gap-1.5 text-xs mb-1.5 flex-wrap;
 }
 
-.smtp-body__addr {
-  @apply text-gray-600 dark:text-gray-300 font-mono;
+.smtp-body__pill {
+  @apply inline-flex items-center px-2 py-0.5 rounded-full;
+  @apply font-mono text-2xs;
+  @apply bg-gray-100 dark:bg-gray-800;
+  @apply text-gray-600 dark:text-gray-300;
 }
 
-.smtp-body__addr-label {
-  @apply text-gray-400 dark:text-gray-500 font-sans mr-1;
+.smtp-body__arrow {
+  @apply w-3.5 h-3.5 flex-shrink-0;
+  @apply text-gray-300 dark:text-gray-600;
 }
 
 .smtp-body__preview {

--- a/src/shared/lib/use-api-transport/use-api-transport.ts
+++ b/src/shared/lib/use-api-transport/use-api-transport.ts
@@ -1,10 +1,14 @@
 import { storeToRefs } from "pinia";
 import type { RayContentLock } from "@/entities/ray/types";
 import {useEventsStore, useConnectionStore, useProfileStore} from "../../stores";
+import type { ServerEvent } from '../../types';
 import type { EventId, EventType } from '../../types';
 import { useCentrifuge, useEventsRequests } from "../io";
 
 let isEventsEmitted = false
+let eventBuffer: ServerEvent<unknown>[] = []
+let flushTimer: ReturnType<typeof setTimeout> | null = null
+const FLUSH_INTERVAL = 500
 
 export const useApiTransport = () => {
   const { token } = storeToRefs(useProfileStore())
@@ -67,7 +71,17 @@ export const useApiTransport = () => {
         const event = ctx?.data?.data || null
 
         if (event && event.project === project.value) {
-          eventsStore.addList([event]);
+          eventBuffer.push(event);
+
+          if (!flushTimer) {
+            flushTimer = setTimeout(() => {
+              if (eventBuffer.length > 0) {
+                eventsStore.addList(eventBuffer);
+                eventBuffer = [];
+              }
+              flushTimer = null;
+            }, FLUSH_INTERVAL);
+          }
         }
       }
     });

--- a/src/shared/stores/events/events-store.ts
+++ b/src/shared/stores/events/events-store.ts
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import { PAGE_TYPES} from "../../constants";
+import { logger } from "../../lib/logger";
 import {useSettings} from "../../lib/use-settings";
 import {
   type EventId,
@@ -36,6 +37,8 @@ const initialCachedIds: TEventsCachedIdsMap = {
 export const useEventsStore = defineStore("eventsStore", {
   state: () => ({
     events: [] as ServerEvent<unknown>[],
+    searchQuery: '' as string,
+    countsMap: new Map<string, number>() as Map<string, number>,
     cachedIds: getStoredCachedIds() || initialCachedIds,
     lockedIds: getStoredLockedIds() || [],
     projects: {
@@ -44,20 +47,11 @@ export const useEventsStore = defineStore("eventsStore", {
     }
   }),
   getters: {
-    eventsCounts: ({events}) => (eventType: EventTypes | undefined): number => {
-      // TODO: need to use common mapping with changed ids
-      const counts = {
-        [EventTypes.VarDump]: events.filter(({type}) => type === EventTypes.VarDump).length,
-        [EventTypes.Smtp]: events.filter(({type}) => type === EventTypes.Smtp).length,
-        [EventTypes.Sentry]: events.filter(({type}) => type === EventTypes.Sentry).length,
-        [EventTypes.Profiler]: events.filter(({type}) => type === EventTypes.Profiler).length,
-        [EventTypes.Monolog]: events.filter(({type}) => type === EventTypes.Monolog).length,
-        [EventTypes.Inspector]: events.filter(({type}) => type === EventTypes.Inspector).length,
-        [EventTypes.HttpDump]: events.filter(({type}) => type === EventTypes.HttpDump).length,
-        [EventTypes.RayDump]: events.filter(({type}) => type === EventTypes.RayDump).length
+    eventsCounts: ({ countsMap, events }) => (eventType: EventTypes | undefined): number => {
+      if (!eventType) {
+        return events.length;
       }
-
-      return eventType && counts[eventType] != null ? counts[eventType] : events.length;
+      return countsMap.get(eventType) ?? 0;
     },
     cachedIdsTypesList({ cachedIds }) {
       return Object.entries(cachedIds).filter(([_, value]) => value.length > 0).map(([key]) => key as PageEventTypes)
@@ -76,6 +70,12 @@ export const useEventsStore = defineStore("eventsStore", {
     ),
   },
   actions: {
+    rebuildCountsMap() {
+      this.countsMap.clear();
+      for (const event of this.events) {
+        this.countsMap.set(event.type, (this.countsMap.get(event.type) ?? 0) + 1);
+      }
+    },
     async initialize (): Promise<void> {
       const {api: { getProjects }} = useSettings();
       this.initActiveProjectKey();
@@ -86,7 +86,7 @@ export const useEventsStore = defineStore("eventsStore", {
           this.setAvailableProjects(data);
         }
       } catch (e) {
-        console.error(e);
+        logger.store.error('Failed to fetch projects', e);
       }
     },
     // events
@@ -97,51 +97,58 @@ export const useEventsStore = defineStore("eventsStore", {
         .filter((el) => availableEvents.includes(el.type as EventType))
         .slice(0, MAX_EVENTS_COUNT);
 
+      this.rebuildCountsMap();
       this.syncCachedWithActive(events.map(({ uuid }) => uuid));
       this.initActiveProjectKey();
     },
     addList(events: ServerEvent<unknown>[]): void {
       const { availableEvents } = useSettingsStore();
+      const existingIds = new Set(this.events.map(e => e.uuid));
+
       events
         .filter((el) => availableEvents.includes(el.type as EventType))
         .forEach((event) => {
-        const isExistedEvent: boolean = this.events.some((el): boolean => el.uuid === event.uuid);
-        if (!isExistedEvent) {
-          this.events.unshift(event)
+        if (!existingIds.has(event.uuid)) {
+          this.events.unshift(event);
+          existingIds.add(event.uuid);
+          this.countsMap.set(event.type, (this.countsMap.get(event.type) ?? 0) + 1);
 
           if (this.events.length > MAX_EVENTS_COUNT) {
-            this.events.pop()
+            const removed = this.events.pop()!;
+            const count = this.countsMap.get(removed.type) ?? 1;
+            this.countsMap.set(removed.type, count - 1);
           }
         } else {
-          this.events = this.events.map((el) => {
-            if (el.uuid !== event.uuid) {
-              return el; // add new
-            }
-
-            return event; // replace existed
-          });
+          this.events = this.events.map((el) => el.uuid === event.uuid ? event : el);
         }
       });
     },
     removeAll() {
       if (this.lockedIds.length) {
         this.events = this.events.filter(({ uuid }) => this.lockedIds.includes(uuid));
+        this.rebuildCountsMap();
 
         return
       }
 
       this.events.length = 0;
+      this.countsMap.clear();
 
       this.removeCachedAll();
     },
     removeByIds(eventUuids: EventId[]) {
+      const uuidSet = new Set(eventUuids);
+
       if (this.lockedIds.length) {
-        this.events = this.events.filter(({ uuid }) => !eventUuids.includes(uuid) || this.lockedIds.includes(uuid));
+        const lockedSet = new Set(this.lockedIds);
+        this.events = this.events.filter(({ uuid }) => !uuidSet.has(uuid) || lockedSet.has(uuid));
+        this.rebuildCountsMap();
 
         return
       }
 
-      this.events = this.events.filter(({ uuid }) => !eventUuids.includes(uuid));
+      this.events = this.events.filter(({ uuid }) => !uuidSet.has(uuid));
+      this.rebuildCountsMap();
 
       this.removeCachedByIds(eventUuids);
     },
@@ -153,11 +160,13 @@ export const useEventsStore = defineStore("eventsStore", {
     removeByType(eventType: EventType) {
       if (this.lockedIds.length) {
         this.events = this.events.filter(({ type, uuid }) => type !== eventType || this.lockedIds.includes(uuid));
+        this.rebuildCountsMap();
 
         return
       }
 
       this.events = this.events.filter(({ type }) => type !== eventType);
+      this.countsMap.set(eventType, 0);
     },
     // cached ids
     addCachedByType(cachedType: PageEventTypes) {

--- a/src/shared/types/events.ts
+++ b/src/shared/types/events.ts
@@ -24,7 +24,8 @@ export interface ServerEvent<T> {
   type: EventType | unknown,
   payload: T,
   project: string | null,
-  timestamp: number // unavailable for some ray dump events
+  timestamp: number, // unavailable for some ray dump events
+  searchable_text?: string,
 }
 
 export interface NormalizedEvent<T> {

--- a/src/shared/ui/code-snippet/code-snippet.vue
+++ b/src/shared/ui/code-snippet/code-snippet.vue
@@ -2,6 +2,7 @@
 import highlightPlugin from '@highlightjs/vue-plugin'
 import isString from 'lodash.isstring'
 import { ref, computed } from 'vue'
+import { logger } from '../../lib/logger'
 import { IconSvg } from '../icon-svg'
 
 const CodeHighlight = highlightPlugin.component
@@ -33,7 +34,7 @@ const copyCode = (): void => {
       }, 1500)
     })
     .catch((e) => {
-      console.error(e)
+      logger.ui.error('Failed to copy code to clipboard', e)
     })
 }
 </script>
@@ -65,7 +66,7 @@ const copyCode = (): void => {
 <style lang="scss" scoped>
 .code-snippet {
   @apply relative rounded overflow-hidden;
-  @apply bg-gray-100 dark:bg-gray-900;
+  @apply bg-gray-50 dark:bg-gray-900;
 
   :deep(pre) {
     @apply m-0;
@@ -73,6 +74,7 @@ const copyCode = (): void => {
 
   :deep(code.hljs) {
     @apply p-4 text-xs leading-relaxed;
+    background: inherit !important;
   }
 }
 

--- a/src/shared/ui/highlight-text/highlight-text.vue
+++ b/src/shared/ui/highlight-text/highlight-text.vue
@@ -1,0 +1,62 @@
+<script lang="ts" setup>
+import { storeToRefs } from 'pinia'
+import { computed } from 'vue'
+import { useEventsStore } from '../../stores'
+
+type Props = {
+  text: string
+}
+
+const props = defineProps<Props>()
+const { searchQuery } = storeToRefs(useEventsStore())
+
+const segments = computed(() => {
+  const query = searchQuery.value.trim().toLowerCase()
+  if (!query || !props.text) {
+    return [{ text: props.text, match: false }]
+  }
+
+  const result: { text: string; match: boolean }[] = []
+  const lower = props.text.toLowerCase()
+  let lastIndex = 0
+
+  let pos = lower.indexOf(query, lastIndex)
+  while (pos !== -1) {
+    if (pos > lastIndex) {
+      result.push({ text: props.text.slice(lastIndex, pos), match: false })
+    }
+    result.push({ text: props.text.slice(pos, pos + query.length), match: true })
+    lastIndex = pos + query.length
+    pos = lower.indexOf(query, lastIndex)
+  }
+
+  if (lastIndex < props.text.length) {
+    result.push({ text: props.text.slice(lastIndex), match: false })
+  }
+
+  return result
+})
+</script>
+
+<template>
+  <template
+    v-for="(seg, i) in segments"
+    :key="i"
+  >
+    <mark
+      v-if="seg.match"
+      class="highlight-text__mark"
+    >{{ seg.text }}</mark>
+    <template v-else>
+      {{ seg.text }}
+    </template>
+  </template>
+</template>
+
+<style lang="scss" scoped>
+.highlight-text__mark {
+  @apply bg-yellow-200 dark:bg-yellow-500/30;
+  @apply text-inherit rounded-sm;
+  padding: 0.05em 0.1em;
+}
+</style>

--- a/src/shared/ui/highlight-text/index.ts
+++ b/src/shared/ui/highlight-text/index.ts
@@ -1,0 +1,1 @@
+export { default as HighlightText } from './highlight-text.vue'

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -12,3 +12,5 @@ export * from './app-header';
 export * from './event-detail-layout';
 export * from './page-tabs';
 export * from './skeleton-loader';
+export * from './search-bar';
+export * from './highlight-text';

--- a/src/shared/ui/preview-card/preview-card-footer.vue
+++ b/src/shared/ui/preview-card/preview-card-footer.vue
@@ -2,6 +2,7 @@
 import { storeToRefs } from 'pinia'
 import { withDefaults, defineProps, computed } from 'vue'
 import { useSettingsStore } from '../../stores/settings'
+import { HighlightText } from '../highlight-text'
 import { IconSvg } from '../icon-svg'
 
 // TODO: Move this to a shared file
@@ -87,7 +88,7 @@ const isEditorLink = (key: string) => !!editorLink.value && (key === 'file' || k
             class="pc-footer__tag pc-footer__tag--link"
           >
             <span class="pc-footer__tag-key">{{ key }}</span>
-            <span class="pc-footer__tag-value">{{ value }}</span>
+            <span class="pc-footer__tag-value"><HighlightText :text="String(value)" /></span>
           </a>
 
           <span
@@ -95,7 +96,7 @@ const isEditorLink = (key: string) => !!editorLink.value && (key === 'file' || k
             class="pc-footer__tag"
           >
             <span class="pc-footer__tag-key">{{ key }}</span>
-            <span class="pc-footer__tag-value">{{ value }}</span>
+            <span class="pc-footer__tag-value"><HighlightText :text="String(value)" /></span>
           </span>
         </template>
       </template>
@@ -109,7 +110,7 @@ const isEditorLink = (key: string) => !!editorLink.value && (key === 'file' || k
         name="host"
         class="pc-footer__host-icon"
       />
-      <span class="pc-footer__host-name">{{ serverName }}</span>
+      <span class="pc-footer__host-name"><HighlightText :text="serverName" /></span>
     </div>
   </div>
 </template>

--- a/src/shared/ui/preview-card/preview-card-header.vue
+++ b/src/shared/ui/preview-card/preview-card-header.vue
@@ -3,6 +3,7 @@ import isString from 'lodash.isstring'
 import { computed, onMounted, onBeforeUnmount, ref } from 'vue'
 import { PAGES_SETTINGS } from '../../constants'
 import { type EventType, type NormalizedEvent, RouteName } from '../../types'
+import { HighlightText } from '../highlight-text'
 import { IconSvg } from '../icon-svg'
 import { DownloadType } from './types'
 
@@ -107,7 +108,7 @@ const isVisibleTags = computed(() => props.labels.length > 0)
             v-if="isString(label)"
             class="pc-header__label"
           >
-            {{ label }}
+            <HighlightText :text="label" />
           </span>
 
           <span
@@ -115,8 +116,8 @@ const isVisibleTags = computed(() => props.labels.length > 0)
             class="pc-header__label pc-header__label--kv"
             :title="label.context"
           >
-            <span class="pc-header__label-key">{{ label.title }}</span>
-            {{ label.value }}
+            <span class="pc-header__label-key"><HighlightText :text="label.title" /></span>
+            <HighlightText :text="label.value" />
           </span>
         </template>
       </template>
@@ -316,7 +317,18 @@ $typeColors: (
 }
 
 .pc-header__type-shape--ray {
-  clip-path: polygon(50% 0%, 61% 35%, 98% 35%, 68% 57%, 79% 91%, 50% 70%, 21% 91%, 32% 57%, 2% 35%, 39% 35%); /* star */
+  clip-path: polygon(
+    50% 0%,
+    61% 35%,
+    98% 35%,
+    68% 57%,
+    79% 91%,
+    50% 70%,
+    21% 91%,
+    32% 57%,
+    2% 35%,
+    39% 35%
+  ); /* star */
 }
 
 .pc-header__type-shape--unknown {

--- a/src/shared/ui/search-bar/index.ts
+++ b/src/shared/ui/search-bar/index.ts
@@ -1,0 +1,1 @@
+export { default as SearchBar } from './search-bar.vue'

--- a/src/shared/ui/search-bar/search-bar.vue
+++ b/src/shared/ui/search-bar/search-bar.vue
@@ -1,0 +1,127 @@
+<script lang="ts" setup>
+import { ref, onMounted, onUnmounted } from 'vue'
+import { IconSvg } from '../icon-svg'
+
+const model = defineModel<string>({ default: '' })
+
+const inputRef = ref<HTMLInputElement | null>(null)
+
+const focus = () => inputRef.value?.focus()
+const clear = () => {
+  model.value = ''
+  focus()
+}
+
+const onKeydown = (e: KeyboardEvent) => {
+  if (e.key === '/' && !isInputFocused()) {
+    e.preventDefault()
+    focus()
+  }
+}
+
+const onInputKeydown = (e: KeyboardEvent) => {
+  if (e.key === 'Escape') {
+    clear()
+    inputRef.value?.blur()
+  }
+}
+
+const isInputFocused = () => {
+  const active = document.activeElement
+  return active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement
+}
+
+onMounted(() => document.addEventListener('keydown', onKeydown))
+onUnmounted(() => document.removeEventListener('keydown', onKeydown))
+</script>
+
+<template>
+  <div class="search-bar">
+    <svg
+      class="search-bar__icon"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path
+        fill-rule="evenodd"
+        d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z"
+        clip-rule="evenodd"
+      />
+    </svg>
+
+    <input
+      ref="inputRef"
+      v-model="model"
+      type="text"
+      class="search-bar__input"
+      placeholder="Search events..."
+      aria-label="Search events"
+      @keydown="onInputKeydown"
+    >
+
+    <kbd
+      v-if="!model"
+      class="search-bar__shortcut"
+    >/</kbd>
+
+    <button
+      v-else
+      class="search-bar__clear"
+      title="Clear search (Escape)"
+      aria-label="Clear search"
+      @click="clear"
+    >
+      <IconSvg
+        name="times"
+        class="search-bar__clear-icon"
+      />
+    </button>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.search-bar {
+  @apply flex items-center gap-2 px-2.5 h-7 rounded flex-1;
+  @apply bg-gray-100 dark:bg-gray-700/60;
+  @apply border border-transparent;
+  @apply transition-colors;
+
+  &:focus-within {
+    @apply border-blue-400 dark:border-blue-500;
+    @apply bg-white dark:bg-gray-800;
+  }
+}
+
+.search-bar__icon {
+  @apply w-3.5 h-3.5 flex-shrink-0;
+  @apply text-gray-400 dark:text-gray-500;
+}
+
+.search-bar__input {
+  @apply bg-transparent outline-none text-xs flex-1 min-w-0;
+  @apply text-gray-800 dark:text-gray-200;
+  @apply placeholder-gray-400 dark:placeholder-gray-500;
+}
+
+.search-bar__shortcut {
+  @apply text-2xs px-1 rounded leading-none;
+  @apply bg-gray-200 dark:bg-gray-600;
+  @apply text-gray-400 dark:text-gray-500;
+  @apply font-mono;
+  padding-top: 1px;
+  padding-bottom: 1px;
+  font-size: 10px;
+}
+
+.search-bar__clear {
+  @apply flex-shrink-0 cursor-pointer;
+  @apply text-gray-400 dark:text-gray-500;
+  @apply hover:text-gray-600 dark:hover:text-gray-300;
+  @apply transition-colors;
+}
+
+.search-bar__clear-icon {
+  @apply w-3.5 h-3.5;
+}
+</style>

--- a/src/shared/ui/value-dump/value-dump.vue
+++ b/src/shared/ui/value-dump/value-dump.vue
@@ -66,7 +66,7 @@ onMounted(() => {
 
 .value-dump__html {
   @apply font-mono break-all text-xs;
-  @apply bg-gray-100 dark:bg-gray-900;
+  @apply bg-gray-50 dark:bg-gray-900;
   @apply rounded overflow-auto;
   @apply p-3;
 }

--- a/src/widgets/ui/layout-preview-events/layout-preview-events.vue
+++ b/src/widgets/ui/layout-preview-events/layout-preview-events.vue
@@ -1,11 +1,13 @@
 <script lang="ts" setup>
-import { useTitle } from '@vueuse/core'
-import { computed, watchEffect } from 'vue'
+import { useTitle, refDebounced } from '@vueuse/core'
+import { toBlob } from 'html-to-image'
+import { storeToRefs } from 'pinia'
+import { computed, ref, watch, watchEffect } from 'vue'
 import { useRouter } from 'vue-router'
 import { PAGE_TYPES } from '@/shared/constants'
 import { useEvents } from '@/shared/lib/use-events'
-import { toBlob } from 'html-to-image'
 import { useKeyboardNav, showToast, screenshotingEventId } from '@/shared/lib/use-keyboard-nav'
+import { useEventsStore } from '@/shared/stores'
 import { type PageEventTypes, RouteName } from '@/shared/types'
 import { EventCardMapper } from '../event-card-mapper'
 import { PagePlaceholder } from '../page-placeholder'
@@ -30,7 +32,7 @@ const allEvents = computed(() => {
   return events.items.value.filter(({ type }) => type === props.type)
 })
 
-const visibleEvents = computed(() => {
+const pauseFilteredEvents = computed(() => {
   if (!isEventsPaused.value) {
     return allEvents.value
   }
@@ -39,6 +41,39 @@ const visibleEvents = computed(() => {
     cachedEvents.idsByType.value[props.type]?.includes(uuid)
   )
 })
+
+const { searchQuery } = storeToRefs(useEventsStore())
+const debouncedSearch = refDebounced(searchQuery, 150)
+
+const visibleEvents = computed(() => {
+  const query = debouncedSearch.value.toLowerCase().trim()
+  if (!query) {
+    return pauseFilteredEvents.value
+  }
+
+  return pauseFilteredEvents.value.filter((event) => {
+    if (event.searchable_text) {
+      return event.searchable_text.toLowerCase().includes(query)
+    }
+    return JSON.stringify(event.payload).toLowerCase().includes(query)
+  })
+})
+
+const recentEventIds = ref(new Set<string>())
+
+watch(
+  () => events.items.value.length,
+  (newLen, oldLen) => {
+    if (newLen > oldLen) {
+      const newIds = events.items.value.slice(0, newLen - oldLen).map((e) => e.uuid)
+      newIds.forEach((id) => recentEventIds.value.add(id))
+
+      setTimeout(() => {
+        newIds.forEach((id) => recentEventIds.value.delete(id))
+      }, 2000)
+    }
+  }
+)
 
 const router = useRouter()
 const eventUuids = computed(() => visibleEvents.value.map((e) => e.uuid))
@@ -72,7 +107,8 @@ const { focusedId } = useKeyboardNav(eventUuids, {
   onCopyPayload: (id) => {
     const event = visibleEvents.value.find((e) => e.uuid === id)
     if (event) {
-      navigator.clipboard.writeText(JSON.stringify(event.payload, null, 2))
+      navigator.clipboard
+        .writeText(JSON.stringify(event.payload, null, 2))
         .then(() => showToast('Payload copied'))
     }
   },
@@ -85,7 +121,8 @@ const { focusedId } = useKeyboardNav(eventUuids, {
         toBlob(el as HTMLElement)
           .then((blob) => {
             if (blob) {
-              navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })])
+              navigator.clipboard
+                .write([new ClipboardItem({ [blob.type]: blob })])
                 .then(() => showToast('Screenshot copied'))
             }
           })
@@ -94,7 +131,7 @@ const { focusedId } = useKeyboardNav(eventUuids, {
           })
       }, 50)
     }
-  },
+  }
 })
 
 watchEffect(() => {
@@ -112,14 +149,16 @@ watchEffect(() => {
       class="layout-preview-events__events"
     >
       <EventCardMapper
-        v-for="(event, index) in visibleEvents"
+        v-for="event in visibleEvents"
         :id="event.uuid"
         :key="event.uuid"
         :event="event"
         role="article"
         class="layout-preview-events__event"
-        :class="{ 'layout-preview-events__event--focused': focusedId === event.uuid }"
-        :style="index < 20 ? { animationDelay: `${index * 30}ms` } : undefined"
+        :class="{
+          'layout-preview-events__event--focused': focusedId === event.uuid,
+          'layout-preview-events__event--animate': recentEventIds.has(event.uuid)
+        }"
       />
     </main>
 
@@ -142,14 +181,17 @@ watchEffect(() => {
 .layout-preview-events__events {
   @include mixins.border-style;
   @apply divide-y divide-gray-200 dark:divide-gray-700;
+  @apply flex-1 overflow-y-auto;
 }
 
 .layout-preview-events__event {
-  animation: event-enter 0.25s ease-out both;
-
   & + & {
     @apply border-b border-gray-200 dark:border-gray-700;
   }
+}
+
+.layout-preview-events__event--animate {
+  animation: event-enter 0.25s ease-out both;
 }
 
 @keyframes event-enter {

--- a/src/widgets/ui/page-header/page-header.vue
+++ b/src/widgets/ui/page-header/page-header.vue
@@ -1,11 +1,15 @@
 <script lang="ts" setup>
+import { storeToRefs } from 'pinia'
 import { computed } from 'vue'
 import { ALL_EVENT_TYPES } from '@/shared/constants'
 import { useEvents } from '@/shared/lib/use-events'
+import { useEventsStore } from '@/shared/stores'
 import { type EventType, type PageEventTypes, RouteName } from '@/shared/types'
-import { AppHeader, PauseButton, IconSvg } from '@/shared/ui'
+import { AppHeader, PauseButton, IconSvg, SearchBar } from '@/shared/ui'
 
 const { events, cachedEvents } = useEvents()
+const eventsStore = useEventsStore()
+const { searchQuery } = storeToRefs(eventsStore)
 
 type Props = {
   type: PageEventTypes
@@ -75,6 +79,8 @@ const toggleUpdate = () => {
     </span>
 
     <template #controls>
+      <SearchBar v-model="searchQuery" />
+
       <PauseButton
         :disabled-pause="visibleEvents.length === 0"
         :is-paused="isEventsPaused"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4881,6 +4881,11 @@ minimist@^1.2.0, minimist@^1.2.6, minimist@^1.2.8:
   resolved "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz"
   integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
 
+mitt@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mitt/-/mitt-2.1.0.tgz#f740577c23176c6205b121b2973514eade1b2230"
+  integrity sha512-ILj2TpLiysu2wkBbWjAmww7TkZb65aiQO+DkVdUTBpBXq+MHYiETENkKFMtsJZX1Lf4pe4QOrTSjIfUwN5lRdg==
+
 mitt@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz"
@@ -6948,6 +6953,13 @@ vue-tsc@^2.0.21:
     "@volar/typescript" "~2.4.8"
     "@vue/language-core" "2.1.10"
     semver "^7.5.4"
+
+vue-virtual-scroller@^2.0.0-beta.10:
+  version "2.0.0-beta.10"
+  resolved "https://registry.yarnpkg.com/vue-virtual-scroller/-/vue-virtual-scroller-2.0.0-beta.10.tgz#00c768a497cdd80d9a3e335b8a1ad50d5f12bc63"
+  integrity sha512-eubwFXRdiT/5kNYbHKXTkNf3XCmZNSDtpTkWB7TTdOB4LYM14Ylqq/pbW6uXOEbbO/pVXQpxdhtdf2Qj2wZpQA==
+  dependencies:
+    mitt "^2.1.0"
 
 vue3-tabs-component@^1.2.0:
   version "1.3.7"


### PR DESCRIPTION
## Summary
- Add `SearchBar` component with `/` keyboard shortcut and Escape to clear
- Add `HighlightText` component for search match highlighting in preview card headers/footers
- Implement 150ms debounced client-side filtering on `searchable_text` field
- Replace 8x `.filter()` `eventsCounts` getter with `Map`-based `countsMap`
- Add 500ms WS event batching buffer in transport layer
- Animate only recently added events (2s window)
- Redesign Monolog preview: titled blocks for context/extra, hide when empty
- Redesign SMTP preview: pill-style From→To with arrow
- Unify code-snippet background color across all cards
- Auto-hide SfDump toolbar, reveal on hover

## Test plan
- [x] Vite build succeeds
- [x] Search filters events by text, highlights matches
- [x] `/` focuses search, Escape clears
- [x] Event counts in sidebar update correctly
- [x] Monolog cards hide empty context/extra blocks
- [x] SMTP cards show pill-style addresses
- [x] SfDump toolbar hidden until hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)