### PR TITLE
feat: SMS entity — preview card, detail page, storybook

### DIFF
--- a/src/entities/sms/index.ts
+++ b/src/entities/sms/index.ts
@@ -1,0 +1,2 @@
+export * from './ui'
+export * from './lib'

--- a/src/entities/sms/lib/index.ts
+++ b/src/entities/sms/lib/index.ts
@@ -1,0 +1,1 @@
+export * from "./use-sms";

--- a/src/entities/sms/lib/normalize-sms-event.ts
+++ b/src/entities/sms/lib/normalize-sms-event.ts
@@ -1,0 +1,22 @@
+import moment from "moment";
+import { EventTypes } from "@/shared/types";
+import type { ServerEvent, NormalizedEvent } from "@/shared/types";
+import type { SmsPayload } from "../types";
+
+export const normalizeSmsEvent = (event: ServerEvent<SmsPayload>): NormalizedEvent<SmsPayload> => {
+  const normalizedEvent: NormalizedEvent<SmsPayload> = {
+    id: event.uuid,
+    type: EventTypes.Sms,
+    labels: [EventTypes.Sms],
+    origin: null,
+    serverName: "",
+    date: event.timestamp ? new Date(event.timestamp * 1000) : null,
+    payload: event.payload
+  }
+
+  if (normalizedEvent.date) {
+    normalizedEvent.labels.unshift(moment(normalizedEvent.date).format("HH:mm:ss"));
+  }
+
+  return normalizedEvent;
+}

--- a/src/entities/sms/lib/use-sms.ts
+++ b/src/entities/sms/lib/use-sms.ts
@@ -1,0 +1,11 @@
+import type { ServerEvent, NormalizedEvent } from '@/shared/types';
+import type { SmsPayload } from "../types";
+import { normalizeSmsEvent } from "./normalize-sms-event";
+
+type TUseSms = () => {
+  normalizeSmsEvent: (event: ServerEvent<SmsPayload>) => NormalizedEvent<SmsPayload>
+}
+
+export const useSms: TUseSms = () => ({
+  normalizeSmsEvent
+})

--- a/src/entities/sms/mocks/index.ts
+++ b/src/entities/sms/mocks/index.ts
@@ -1,0 +1,13 @@
+import smsGenericMock from './sms-generic.json';
+import smsTwilioWarningsMock from './sms-twilio-warnings.json';
+import smsTwilioMock from './sms-twilio.json';
+import smsVonageWarningsMock from './sms-vonage-warnings.json';
+import smsVonageMock from './sms-vonage.json';
+
+export {
+  smsTwilioMock,
+  smsVonageMock,
+  smsGenericMock,
+  smsTwilioWarningsMock,
+  smsVonageWarningsMock,
+}

--- a/src/entities/sms/mocks/sms-generic.json
+++ b/src/entities/sms/mocks/sms-generic.json
@@ -1,0 +1,12 @@
+{
+  "uuid": "01234567-0000-0000-0000-000000000003",
+  "type": "sms",
+  "timestamp": 1700000120,
+  "project": null,
+  "payload": {
+    "from": "+1555000111",
+    "to": "+1555000222",
+    "message": "Reminder: Your appointment is scheduled for tomorrow at 10:00 AM. Reply CONFIRM to confirm or CANCEL to reschedule.",
+    "gateway": "generic"
+  }
+}

--- a/src/entities/sms/mocks/sms-twilio-warnings.json
+++ b/src/entities/sms/mocks/sms-twilio-warnings.json
@@ -1,0 +1,13 @@
+{
+  "uuid": "01234567-0000-0000-0000-000000000010",
+  "type": "sms",
+  "timestamp": 1700000300,
+  "project": null,
+  "payload": {
+    "from": "+1234567890",
+    "to": "+0987654321",
+    "message": "",
+    "gateway": "twilio",
+    "warnings": ["MessageSid", "Body"]
+  }
+}

--- a/src/entities/sms/mocks/sms-twilio.json
+++ b/src/entities/sms/mocks/sms-twilio.json
@@ -1,0 +1,12 @@
+{
+  "uuid": "01234567-0000-0000-0000-000000000001",
+  "type": "sms",
+  "timestamp": 1700000000,
+  "project": null,
+  "payload": {
+    "from": "+1234567890",
+    "to": "+0987654321",
+    "message": "Your verification code is 4892. Valid for 10 minutes.",
+    "gateway": "twilio"
+  }
+}

--- a/src/entities/sms/mocks/sms-vonage-warnings.json
+++ b/src/entities/sms/mocks/sms-vonage-warnings.json
@@ -1,0 +1,13 @@
+{
+  "uuid": "01234567-0000-0000-0000-000000000011",
+  "type": "sms",
+  "timestamp": 1700000360,
+  "project": null,
+  "payload": {
+    "from": "+31612345678",
+    "to": "+31698765432",
+    "message": "This message is missing auth credentials.",
+    "gateway": "vonage",
+    "warnings": ["api_key", "api_secret"]
+  }
+}

--- a/src/entities/sms/mocks/sms-vonage.json
+++ b/src/entities/sms/mocks/sms-vonage.json
@@ -1,0 +1,12 @@
+{
+  "uuid": "01234567-0000-0000-0000-000000000002",
+  "type": "sms",
+  "timestamp": 1700000060,
+  "project": null,
+  "payload": {
+    "from": "+31612345678",
+    "to": "+31698765432",
+    "message": "Your login code is 829103. Do not share it with anyone.",
+    "gateway": "vonage"
+  }
+}

--- a/src/entities/sms/types.ts
+++ b/src/entities/sms/types.ts
@@ -1,0 +1,7 @@
+export interface SmsPayload {
+  from: string
+  to: string
+  message: string
+  gateway: string
+  warnings?: string[]
+}

--- a/src/entities/sms/ui/index.ts
+++ b/src/entities/sms/ui/index.ts
@@ -1,0 +1,2 @@
+export * from './preview-card';
+export * from './sms-page';

--- a/src/entities/sms/ui/preview-card/index.ts
+++ b/src/entities/sms/ui/preview-card/index.ts
@@ -1,0 +1,3 @@
+import PreviewCard from './preview-card.vue';
+
+export { PreviewCard };

--- a/src/entities/sms/ui/preview-card/preview-card.stories.ts
+++ b/src/entities/sms/ui/preview-card/preview-card.stories.ts
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+import { useSms } from "../../lib";
+import { smsTwilioMock, smsVonageMock, smsGenericMock, smsTwilioWarningsMock, smsVonageWarningsMock } from '../../mocks';
+import PreviewCard from './preview-card.vue';
+
+const { normalizeSmsEvent } = useSms();
+
+export default {
+  title: "Entities/SMS/PreviewCard",
+  component: PreviewCard
+} as Meta<typeof PreviewCard>;
+
+export const Twilio: StoryObj<typeof PreviewCard> = {
+  args: {
+    event: normalizeSmsEvent(smsTwilioMock),
+  }
+};
+
+export const Vonage: StoryObj<typeof PreviewCard> = {
+  args: {
+    event: normalizeSmsEvent(smsVonageMock),
+  }
+};
+
+export const Generic: StoryObj<typeof PreviewCard> = {
+  args: {
+    event: normalizeSmsEvent(smsGenericMock),
+  }
+};
+
+export const TwilioWithWarnings: StoryObj<typeof PreviewCard> = {
+  args: {
+    event: normalizeSmsEvent(smsTwilioWarningsMock),
+  }
+};
+
+export const VonageWithWarnings: StoryObj<typeof PreviewCard> = {
+  args: {
+    event: normalizeSmsEvent(smsVonageWarningsMock),
+  }
+};

--- a/src/entities/sms/ui/preview-card/preview-card.vue
+++ b/src/entities/sms/ui/preview-card/preview-card.vue
@@ -1,0 +1,189 @@
+<script lang="ts" setup>
+import { computed } from 'vue'
+import type { NormalizedEvent } from '@/shared/types'
+import { PreviewCard } from '@/shared/ui'
+import type { SmsPayload } from '../../types'
+
+type Props = {
+  event: NormalizedEvent<SmsPayload>
+}
+
+const props = defineProps<Props>()
+
+const eventLink = computed(() => `/sms/${props.event.id}`)
+
+const textPreview = computed(() => {
+  const t = props.event.payload.message || ''
+  const trimmed = t.replace(/\s+/g, ' ').trim()
+  return trimmed.length > 120 ? `${trimmed.substring(0, 120)}...` : trimmed
+})
+
+const GATEWAY_COLORS: Record<string, string> = {
+  twilio: 'sms-body__badge--twilio',
+  vonage: 'sms-body__badge--vonage',
+  plivo: 'sms-body__badge--plivo',
+  sinch: 'sms-body__badge--sinch',
+  generic: 'sms-body__badge--generic'
+}
+
+const gatewayClass = computed(
+  () => GATEWAY_COLORS[props.event.payload.gateway] || GATEWAY_COLORS.generic
+)
+
+const hasWarnings = computed(
+  () => props.event.payload.warnings && props.event.payload.warnings.length > 0
+)
+</script>
+
+<template>
+  <PreviewCard :event="event">
+    <RouterLink
+      :to="eventLink"
+      class="sms-body"
+    >
+      <div class="sms-body__header">
+        <div class="sms-body__flow">
+          <span
+            v-if="event.payload.from"
+            class="sms-body__pill"
+          >{{ event.payload.from }}</span>
+
+          <svg
+            v-if="event.payload.from && event.payload.to"
+            class="sms-body__arrow"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <line
+              x1="5"
+              y1="12"
+              x2="19"
+              y2="12"
+            />
+            <polyline points="12 5 19 12 12 19" />
+          </svg>
+
+          <span
+            v-if="event.payload.to"
+            class="sms-body__pill"
+          >{{ event.payload.to }}</span>
+        </div>
+
+        <div class="sms-body__badges">
+          <span
+            v-if="hasWarnings"
+            class="sms-body__badge sms-body__badge--warning"
+            :title="event.payload.warnings?.join(', ')"
+          >{{ event.payload.warnings?.length }} warning{{
+            event.payload.warnings && event.payload.warnings.length > 1 ? 's' : ''
+          }}</span>
+          <span
+            v-if="event.payload.gateway"
+            class="sms-body__badge"
+            :class="gatewayClass"
+          >{{
+            event.payload.gateway
+          }}</span>
+        </div>
+      </div>
+
+      <p
+        v-if="textPreview"
+        class="sms-body__preview"
+      >
+        {{ textPreview }}
+      </p>
+
+      <div
+        v-if="hasWarnings"
+        class="sms-body__warnings"
+      >
+        <span
+          v-for="w in event.payload.warnings"
+          :key="w"
+          class="sms-body__warning-item"
+        >Missing: {{ w }}</span>
+      </div>
+    </RouterLink>
+  </PreviewCard>
+</template>
+
+<style lang="scss" scoped>
+.sms-body {
+  @apply block p-3 rounded cursor-pointer;
+  @apply bg-gray-50 dark:bg-gray-900;
+  @apply border border-gray-200 dark:border-gray-700;
+  @apply hover:border-gray-300 dark:hover:border-gray-600 transition-colors;
+}
+
+.sms-body__header {
+  @apply flex items-start justify-between gap-2 mb-1.5;
+}
+
+.sms-body__flow {
+  @apply flex items-center gap-1.5 text-xs flex-wrap;
+}
+
+.sms-body__pill {
+  @apply inline-flex items-center px-2 py-0.5 rounded-full;
+  @apply font-mono text-2xs;
+  @apply bg-gray-100 dark:bg-gray-800;
+  @apply text-gray-600 dark:text-gray-300;
+}
+
+.sms-body__arrow {
+  @apply w-3.5 h-3.5 flex-shrink-0;
+  @apply text-gray-300 dark:text-gray-600;
+}
+
+.sms-body__badge {
+  @apply text-2xs font-mono font-medium px-1.5 py-0.5 rounded flex-shrink-0;
+}
+
+.sms-body__badge--twilio {
+  @apply bg-red-100 dark:bg-red-500/15 text-red-700 dark:text-red-400;
+}
+
+.sms-body__badge--vonage {
+  @apply bg-blue-100 dark:bg-blue-500/15 text-blue-700 dark:text-blue-400;
+}
+
+.sms-body__badge--plivo {
+  @apply bg-green-100 dark:bg-green-500/15 text-green-700 dark:text-green-400;
+}
+
+.sms-body__badge--sinch {
+  @apply bg-purple-100 dark:bg-purple-500/15 text-purple-700 dark:text-purple-400;
+}
+
+.sms-body__badge--generic {
+  @apply bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300;
+}
+
+.sms-body__badges {
+  @apply flex gap-1.5 flex-shrink-0;
+}
+
+.sms-body__badge--warning {
+  @apply bg-red-100 dark:bg-red-500/15 text-red-700 dark:text-red-400;
+}
+
+.sms-body__preview {
+  @apply text-xs text-gray-400 dark:text-gray-500 leading-relaxed line-clamp-2;
+}
+
+.sms-body__warnings {
+  @apply flex flex-wrap gap-1 mt-1.5;
+}
+
+.sms-body__warning-item {
+  @apply inline-flex items-center px-1.5 py-0.5 rounded;
+  @apply text-2xs font-mono;
+  @apply bg-red-50 dark:bg-red-500/10;
+  @apply text-red-600 dark:text-red-400;
+}
+</style>

--- a/src/entities/sms/ui/sms-page/index.ts
+++ b/src/entities/sms/ui/sms-page/index.ts
@@ -1,0 +1,1 @@
+export { default as SmsPage } from './sms-page.vue'

--- a/src/entities/sms/ui/sms-page/sms-page.stories.ts
+++ b/src/entities/sms/ui/sms-page/sms-page.stories.ts
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+import { useSms } from "../../lib";
+import { smsTwilioMock, smsVonageMock, smsGenericMock, smsTwilioWarningsMock, smsVonageWarningsMock } from '../../mocks';
+import SmsPage from "./sms-page.vue";
+
+const { normalizeSmsEvent } = useSms();
+
+export default {
+  title: "Entities/SMS/SmsPage",
+  component: SmsPage,
+  parameters: {
+    layout: 'fullscreen',
+  }
+} as Meta<typeof SmsPage>;
+
+export const Twilio: StoryObj<typeof SmsPage> = {
+  args: {
+    event: normalizeSmsEvent(smsTwilioMock)
+  }
+};
+
+export const Vonage: StoryObj<typeof SmsPage> = {
+  args: {
+    event: normalizeSmsEvent(smsVonageMock)
+  }
+};
+
+export const Generic: StoryObj<typeof SmsPage> = {
+  args: {
+    event: normalizeSmsEvent(smsGenericMock)
+  }
+};
+
+export const TwilioWithWarnings: StoryObj<typeof SmsPage> = {
+  args: {
+    event: normalizeSmsEvent(smsTwilioWarningsMock)
+  }
+};
+
+export const VonageWithWarnings: StoryObj<typeof SmsPage> = {
+  args: {
+    event: normalizeSmsEvent(smsVonageWarningsMock)
+  }
+};

--- a/src/entities/sms/ui/sms-page/sms-page.vue
+++ b/src/entities/sms/ui/sms-page/sms-page.vue
@@ -1,0 +1,290 @@
+<script lang="ts" setup>
+import moment from 'moment'
+import { computed } from 'vue'
+import type { NormalizedEvent } from '@/shared/types'
+import { EventDetailLayout } from '@/shared/ui'
+import type { SmsPayload } from '../../types'
+
+type Props = {
+  event: NormalizedEvent<SmsPayload>
+}
+
+const props = defineProps<Props>()
+
+const date = computed(() => moment(props.event.date).format('DD.MM.YYYY HH:mm:ss'))
+const relativeDate = computed(() => moment(props.event.date).fromNow())
+
+const GATEWAY_COLORS: Record<string, string> = {
+  twilio: 'sms-page__badge--twilio',
+  vonage: 'sms-page__badge--vonage',
+  plivo: 'sms-page__badge--plivo',
+  sinch: 'sms-page__badge--sinch',
+  generic: 'sms-page__badge--generic'
+}
+
+const gatewayClass = computed(
+  () => GATEWAY_COLORS[props.event.payload.gateway] || GATEWAY_COLORS.generic
+)
+
+const hasWarnings = computed(
+  () => props.event.payload.warnings && props.event.payload.warnings.length > 0
+)
+</script>
+
+<template>
+  <EventDetailLayout>
+    <template #header>
+      <div class="sms-page__header">
+        <div class="sms-page__header-top">
+          <h2 class="sms-page__title">
+            SMS Message
+          </h2>
+          <span
+            class="sms-page__badge"
+            :class="gatewayClass"
+          >{{ event.payload.gateway }}</span>
+        </div>
+
+        <div class="sms-page__meta">
+          <span class="sms-page__flow">
+            <span class="sms-page__from">{{ event.payload.from }}</span>
+            <span class="sms-page__arrow">&rarr;</span>
+            <span class="sms-page__to">{{ event.payload.to }}</span>
+          </span>
+          <span class="sms-page__date">
+            {{ date }}
+            <span class="sms-page__relative">({{ relativeDate }})</span>
+          </span>
+        </div>
+      </div>
+    </template>
+
+    <!-- Warnings banner -->
+    <div
+      v-if="hasWarnings"
+      class="sms-page__warnings"
+    >
+      <div class="sms-page__warnings-header">
+        Validation Warnings
+        <span class="sms-page__warnings-count">{{ event.payload.warnings?.length }}</span>
+      </div>
+      <div class="sms-page__warnings-list">
+        <div
+          v-for="w in event.payload.warnings"
+          :key="w"
+          class="sms-page__warning-item"
+        >
+          <span class="sms-page__warning-label">Missing field</span>
+          <code class="sms-page__warning-field">{{ w }}</code>
+        </div>
+      </div>
+    </div>
+
+    <div class="sms-page__layout">
+      <!-- Left: metadata -->
+      <div class="sms-page__info">
+        <section class="sms-card">
+          <h3 class="sms-card__title">
+            Details
+          </h3>
+          <div class="sms-info-rows">
+            <div class="sms-info-row">
+              <span class="sms-info-row__label">From</span>
+              <span class="sms-info-row__value">{{ event.payload.from }}</span>
+            </div>
+            <div class="sms-info-row">
+              <span class="sms-info-row__label">To</span>
+              <span class="sms-info-row__value">{{ event.payload.to }}</span>
+            </div>
+            <div class="sms-info-row">
+              <span class="sms-info-row__label">Gateway</span>
+              <span class="sms-info-row__value">
+                <span
+                  class="sms-page__badge sms-page__badge--inline"
+                  :class="gatewayClass"
+                >{{
+                  event.payload.gateway
+                }}</span>
+              </span>
+            </div>
+            <div class="sms-info-row">
+              <span class="sms-info-row__label">Date</span>
+              <span class="sms-info-row__value">{{ date }}</span>
+            </div>
+          </div>
+        </section>
+      </div>
+
+      <!-- Right: message body -->
+      <div class="sms-page__content">
+        <section class="sms-card">
+          <h3 class="sms-card__title">
+            Message
+          </h3>
+          <pre class="sms-page__message">{{ event.payload.message }}</pre>
+        </section>
+      </div>
+    </div>
+  </EventDetailLayout>
+</template>
+
+<style lang="scss" scoped>
+/* Header */
+.sms-page__header-top {
+  @apply flex items-start justify-between gap-3 mb-2;
+}
+
+.sms-page__title {
+  @apply text-base md:text-lg lg:text-xl font-semibold;
+}
+
+.sms-page__badge {
+  @apply text-2xs font-mono font-semibold uppercase px-2 py-0.5 rounded;
+}
+
+.sms-page__badge--inline {
+  @apply text-2xs;
+}
+
+.sms-page__badge--twilio {
+  @apply bg-red-100 dark:bg-red-500/15 text-red-700 dark:text-red-400;
+}
+
+.sms-page__badge--vonage {
+  @apply bg-blue-100 dark:bg-blue-500/15 text-blue-700 dark:text-blue-400;
+}
+
+.sms-page__badge--plivo {
+  @apply bg-green-100 dark:bg-green-500/15 text-green-700 dark:text-green-400;
+}
+
+.sms-page__badge--sinch {
+  @apply bg-purple-100 dark:bg-purple-500/15 text-purple-700 dark:text-purple-400;
+}
+
+.sms-page__badge--generic {
+  @apply bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300;
+}
+
+.sms-page__meta {
+  @apply flex flex-wrap items-center gap-x-4 gap-y-1;
+}
+
+.sms-page__flow {
+  @apply flex items-center gap-1.5 text-sm;
+}
+
+.sms-page__from {
+  @apply font-medium;
+}
+
+.sms-page__arrow {
+  @apply text-gray-400 dark:text-gray-500;
+}
+
+.sms-page__to {
+  @apply text-gray-600 dark:text-gray-300;
+}
+
+.sms-page__date {
+  @apply text-xs font-mono text-gray-500 dark:text-gray-400;
+}
+
+.sms-page__relative {
+  @apply text-gray-400 dark:text-gray-500;
+}
+
+/* Layout */
+.sms-page__layout {
+  @apply flex flex-col xl:flex-row gap-5;
+}
+
+.sms-page__info {
+  @apply flex flex-col gap-4;
+  @apply xl:w-[38%] xl:flex-shrink-0;
+  @apply order-2 xl:order-1;
+}
+
+.sms-page__content {
+  @apply flex-1 min-w-0;
+  @apply order-1 xl:order-2;
+}
+
+/* Cards */
+.sms-card {
+  @apply rounded-lg overflow-hidden;
+  @apply border border-gray-200 dark:border-gray-700;
+}
+
+.sms-card__title {
+  @apply text-xs font-semibold uppercase tracking-wider;
+  @apply text-gray-500 dark:text-gray-400;
+  @apply px-4 py-2.5;
+  @apply bg-gray-50 dark:bg-gray-900;
+  @apply border-b border-gray-200 dark:border-gray-700;
+}
+
+/* Info rows */
+.sms-info-rows {
+  @apply divide-y divide-gray-100 dark:divide-gray-700/50;
+}
+
+.sms-info-row {
+  @apply flex items-start gap-3 px-4 py-2;
+  @apply text-xs;
+}
+
+.sms-info-row__label {
+  @apply font-medium text-gray-400 dark:text-gray-500;
+  @apply w-24 flex-shrink-0;
+}
+
+.sms-info-row__value {
+  @apply font-mono break-all;
+}
+
+/* Warnings */
+.sms-page__warnings {
+  @apply rounded-lg overflow-hidden mb-4;
+  @apply border border-red-200 dark:border-red-800/50;
+  @apply bg-red-50/50 dark:bg-red-950/20;
+}
+
+.sms-page__warnings-header {
+  @apply text-xs font-semibold uppercase tracking-wider;
+  @apply text-red-600 dark:text-red-400;
+  @apply px-4 py-2.5;
+  @apply bg-red-100/50 dark:bg-red-900/20;
+  @apply border-b border-red-200 dark:border-red-800/50;
+  @apply flex items-center gap-2;
+}
+
+.sms-page__warnings-count {
+  @apply font-normal text-red-400 dark:text-red-500;
+}
+
+.sms-page__warnings-list {
+  @apply divide-y divide-red-100 dark:divide-red-800/30;
+}
+
+.sms-page__warning-item {
+  @apply flex items-center gap-3 px-4 py-2 text-xs;
+}
+
+.sms-page__warning-label {
+  @apply text-red-500 dark:text-red-400 font-medium w-24 flex-shrink-0;
+}
+
+.sms-page__warning-field {
+  @apply font-mono text-red-700 dark:text-red-300;
+  @apply bg-red-100 dark:bg-red-500/15 px-1.5 py-0.5 rounded;
+}
+
+/* Message */
+.sms-page__message {
+  @apply text-sm font-mono p-4 whitespace-pre-wrap break-words;
+  @apply text-gray-700 dark:text-gray-200;
+  @apply bg-white dark:bg-gray-800;
+  @apply min-h-[120px];
+}
+</style>

--- a/src/shared/constants/pages.ts
+++ b/src/shared/constants/pages.ts
@@ -61,5 +61,11 @@ export const PAGES_SETTINGS: { [key in OneOfValues<typeof PAGE_TYPES> ]: { title
     sidebarTitle: 'Ray dump logs',
     iconName: 'ray',
     eventType: EventTypes.RayDump,
+  },
+  [PAGE_TYPES.Sms]: {
+    title: 'SMS',
+    sidebarTitle: 'SMS messages',
+    iconName: 'sms',
+    eventType: EventTypes.Sms,
   }
 }

--- a/src/shared/stores/events/events-store.ts
+++ b/src/shared/stores/events/events-store.ts
@@ -27,6 +27,7 @@ const initialCachedIds: TEventsCachedIdsMap = {
   [PAGE_TYPES.Inspector]: [] as EventId[],
   [PAGE_TYPES.Profiler]: [] as EventId[],
   [PAGE_TYPES.Smtp]: [] as EventId[],
+  [PAGE_TYPES.Sms]: [] as EventId[],
   [PAGE_TYPES.RayDump]: [] as EventId[],
   [PAGE_TYPES.VarDump]: [] as EventId[],
   [PAGE_TYPES.HttpDump]: [] as EventId[],

--- a/src/shared/types/events.ts
+++ b/src/shared/types/events.ts
@@ -10,6 +10,7 @@ export enum EventTypes {
   Inspector = "inspector",
   HttpDump = "http-dump",
   RayDump = "ray",
+  Sms = "sms",
 }
 
 // TODO: add T prefix to all types

--- a/src/shared/ui/icon-svg/icon-svg-originals/sms.svg
+++ b/src/shared/ui/icon-svg/icon-svg-originals/sms.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+  <path d="M8 10h.01"/>
+  <path d="M12 10h.01"/>
+  <path d="M16 10h.01"/>
+</svg>

--- a/src/shared/ui/preview-card/preview-card-header.vue
+++ b/src/shared/ui/preview-card/preview-card-header.vue
@@ -231,18 +231,20 @@ const isVisibleTags = computed(() => props.labels.length > 0)
    Tailwind safelist:
    'text-rose-500 bg-rose-500/10' 'text-violet-500 bg-violet-500/10'
    'text-amber-500 bg-amber-500/10' 'text-green-500 bg-green-500/10'
-   'text-yellow-500 bg-yellow-500/10' 'text-red-500 bg-red-500/10'
+   'text-lime-500 bg-lime-500/10' 'text-sky-500 bg-sky-500/10'
    'text-teal-500 bg-teal-500/10' 'text-cyan-500 bg-cyan-500/10'
+   'text-fuchsia-500 bg-fuchsia-500/10'
    'text-teal-600 dark:text-teal-400 bg-teal-50 dark:bg-teal-500/10' */
 $typeColors: (
   'sentry': 'rose',
   'profiler': 'violet',
   'smtp': 'amber',
   'http-dump': 'green',
-  'inspector': 'yellow',
-  'var-dump': 'orange',
+  'inspector': 'lime',
+  'var-dump': 'sky',
   'monolog': 'teal',
   'ray': 'cyan',
+  'sms': 'fuchsia',
   'unknown': 'gray'
 );
 

--- a/src/shared/ui/preview-card/preview-card.vue
+++ b/src/shared/ui/preview-card/preview-card.vue
@@ -188,16 +188,18 @@ onMounted(() => {
    Tailwind safelist comment for JIT:
    'border-l-rose-500' 'border-l-violet-500' 'border-l-amber-500'
    'border-l-green-500' 'border-l-yellow-500' 'border-l-orange-500'
-   'border-l-teal-500' 'border-l-cyan-500' */
+   'border-l-teal-500' 'border-l-cyan-500' 'border-l-fuchsia-500'
+   'border-l-lime-500' 'border-l-sky-500' */
 $typeStripeMap: (
   'sentry': 'rose',
   'profiler': 'violet',
   'smtp': 'amber',
   'http-dump': 'green',
-  'inspector': 'yellow',
-  'var-dump': 'orange',
+  'inspector': 'lime',
+  'var-dump': 'sky',
   'monolog': 'teal',
-  'ray': 'cyan'
+  'ray': 'cyan',
+  'sms': 'fuchsia'
 );
 
 .preview-card {

--- a/src/widgets/ui/event-card-mapper/event-card-mapper.stories.ts
+++ b/src/widgets/ui/event-card-mapper/event-card-mapper.stories.ts
@@ -5,6 +5,7 @@ import { inspectorMock } from '@/entities/inspector/mocks';
 import { monologMock } from '@/entities/monolog/mocks';
 import { profilerMock } from  "@/entities/profiler/mocks";
 import { sentrySpiralMock } from '@/entities/sentry/mocks';
+import { smsTwilioMock, smsTwilioWarningsMock } from '@/entities/sms/mocks';
 import { smtpWelcomeMock } from '@/entities/smtp/mocks';
 import { varDumpObjectMock } from "@/entities/var-dump/mocks";
 import EventCardMapper from "./event-card-mapper.vue";
@@ -62,10 +63,24 @@ export const HttpDump: StoryObj<typeof EventCardMapper> = {
   }
 };
 
+export const Sms: StoryObj<typeof EventCardMapper> = {
+  args: {
+    event: smsTwilioMock,
+  }
+};
+
+export const SmsWithWarnings: StoryObj<typeof EventCardMapper> = {
+  args: {
+    event: smsTwilioWarningsMock,
+  }
+};
+
 const eventsList = [
   monologMock,
   sentrySpiralMock,
   smtpWelcomeMock,
+  smsTwilioMock,
+  smsTwilioWarningsMock,
   varDumpObjectMock,
   profilerMock,
   inspectorMock,

--- a/src/widgets/ui/event-card-mapper/event-card-mapper.vue
+++ b/src/widgets/ui/event-card-mapper/event-card-mapper.vue
@@ -6,6 +6,7 @@ import { useMonolog, PreviewCard as PreviewMonolog } from '@/entities/monolog'
 import { useProfiler, PreviewCard as PreviewProfiler } from '@/entities/profiler'
 import { useRay, PreviewCard as PreviewRay } from '@/entities/ray'
 import { useSentry, PreviewCard as PreviewSentry } from '@/entities/sentry'
+import { useSms, PreviewCard as PreviewSms } from '@/entities/sms'
 import { useSmtp, PreviewCard as PreviewSMTP } from '@/entities/smtp'
 import { useVarDump, PreviewCard as PreviewVarDump } from '@/entities/var-dump'
 import { useEvents } from '@/shared/lib/use-events'
@@ -23,6 +24,7 @@ const { normalizeProfilerEvent } = useProfiler()
 const { normalizeVarDumpEvent } = useVarDump()
 const { normalizeMonologEvent } = useMonolog()
 const { normalizeSentryEvent } = useSentry()
+const { normalizeSmsEvent } = useSms()
 const { normalizeSmtpEvent } = useSmtp()
 const { normalizeInspectorEvent } = useInspector()
 const { normalizeHttpDumpEvent } = useHttpDump()
@@ -66,6 +68,10 @@ const EVENT_TYPE_COMPONENTS_MAP: Record<EventTypes, MappedEventsProps<unknown>> 
   [EventTypes.HttpDump]: {
     view: PreviewHttpDump,
     normalize: normalizeHttpDumpEvent
+  },
+  [EventTypes.Sms]: {
+    view: PreviewSms,
+    normalize: normalizeSmsEvent
   },
   unknown: {
     view: PreviewCardDefault,

--- a/src/widgets/ui/event-page-mapper/event-page-mapper.vue
+++ b/src/widgets/ui/event-page-mapper/event-page-mapper.vue
@@ -6,6 +6,7 @@ import { useMonolog, MonologPage } from '@/entities/monolog'
 import { useProfiler, ProfilerPage } from '@/entities/profiler'
 import { useRay, RayPage } from '@/entities/ray'
 import { useSentry, SentryPage } from '@/entities/sentry'
+import { useSms, SmsPage } from '@/entities/sms'
 import { useSmtp, SmtpPage } from '@/entities/smtp'
 import { useVarDump, VarDumpPage } from '@/entities/var-dump'
 import { useEvents } from '@/shared/lib/use-events'
@@ -17,6 +18,7 @@ const { normalizeProfilerEvent } = useProfiler()
 const { normalizeVarDumpEvent } = useVarDump()
 const { normalizeMonologEvent } = useMonolog()
 const { normalizeSentryEvent } = useSentry()
+const { normalizeSmsEvent } = useSms()
 const { normalizeSmtpEvent } = useSmtp()
 const { normalizeInspectorEvent } = useInspector()
 const { normalizeHttpDumpEvent } = useHttpDump()
@@ -60,6 +62,10 @@ const EVENT_TYPE_COMPONENTS_MAP: Record<EventTypes, MappedEventsProps<unknown>> 
   [EventTypes.HttpDump]: {
     view: HttpDumpPage,
     normalize: normalizeHttpDumpEvent
+  },
+  [EventTypes.Sms]: {
+    view: SmsPage,
+    normalize: normalizeSmsEvent
   }
 } as Record<EventTypes, MappedEventsProps<unknown>>
 


### PR DESCRIPTION
## Summary

- Add `sms` entity with full UI for SMS Gateway Interceptor
- Preview card: `from → to` pill flow, gateway badge (colored per provider), message preview, validation warnings
- Detail page: metadata table, full message body, validation warnings section (red banner with missing fields)
- Storybook stories for all variants: Twilio, Vonage, Generic, TwilioWithWarnings, VonageWithWarnings
- SMS icon in sidebar, event type color: fuchsia
- Updated event type colors for better contrast: Inspector=lime, VarDump=sky
- Registered in event-card-mapper and event-page-mapper
- Added to PAGES_SETTINGS, initialCachedIds, EventTypes enum

### Related
- Server PR: https://github.com/buggregator/server/pull/318

## Test plan
- [x] TypeScript compiles with zero errors
- [x] Storybook stories render correctly
- [x] Manual test: verify SMS events display in UI with correct gateway badges and warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)