### PR TITLE
feat(monolog): color-coded log level labels

### DIFF
--- a/src/entities/monolog/lib/use-monolog/normalize-monolog.ts
+++ b/src/entities/monolog/lib/use-monolog/normalize-monolog.ts
@@ -1,12 +1,30 @@
 import moment from "moment/moment";
-import {type ServerEvent, type NormalizedEvent, EventTypes} from "@/shared/types";
+import {type ServerEvent, type NormalizedEvent, type LabelColor, EventTypes} from "@/shared/types";
 import type { Monolog } from "../../types";
 
+const levelColorMap: Record<string, LabelColor> = {
+  DEBUG: 'gray',
+  INFO: 'blue',
+  NOTICE: 'cyan',
+  WARNING: 'amber',
+  ERROR: 'red',
+  CRITICAL: 'red',
+  ALERT: 'orange',
+  EMERGENCY: 'red',
+}
+
 export const normalizeMonolog = (event: ServerEvent<Monolog>): NormalizedEvent<Monolog> => {
+  const levelName = event.payload.level_name || 'DEBUG'
+  const levelColor = levelColorMap[levelName] || 'gray'
+
   const normalizedEvent: NormalizedEvent<Monolog> = {
     id: event.uuid,
     type: EventTypes.Monolog,
-    labels: [EventTypes.Monolog, event.payload.channel],
+    labels: [
+      EventTypes.Monolog,
+      { text: levelName, color: levelColor },
+      event.payload.channel,
+    ],
     origin: event.payload?.context?.source || null,
     serverName: "",
     date: event.timestamp ? new Date(event.timestamp * 1000) : null,

--- a/src/entities/monolog/mocks/index.ts
+++ b/src/entities/monolog/mocks/index.ts
@@ -5,3 +5,14 @@ export {
   monologMock,
   monologExtendedMock,
 }
+
+export {
+  monologDebugMock,
+  monologInfoMock,
+  monologNoticeMock,
+  monologWarningMock,
+  monologErrorMock,
+  monologCriticalMock,
+  monologAlertMock,
+  monologEmergencyMock,
+} from './monolog-levels'

--- a/src/entities/monolog/mocks/monolog-levels.ts
+++ b/src/entities/monolog/mocks/monolog-levels.ts
@@ -1,0 +1,62 @@
+import type { ServerEvent } from '@/shared/types'
+import type { Monolog } from '../types'
+
+const createMonologMock = (
+  level: number,
+  levelName: string,
+  message: string,
+): ServerEvent<Monolog> => ({
+  uuid: `monolog-${levelName.toLowerCase()}-${crypto.randomUUID?.() || Math.random().toString(36).slice(2)}`,
+  type: 'monolog',
+  payload: {
+    message,
+    context: { foo: 'bar' },
+    level,
+    level_name: levelName,
+    channel: 'application',
+    datetime: '2024-06-27T15:59:34.201624+02:00',
+    extra: [],
+  },
+  timestamp: 1719496774,
+  project: null,
+} as unknown as ServerEvent<Monolog>)
+
+export const monologDebugMock = createMonologMock(
+  100, 'DEBUG',
+  'Loading configuration from /etc/app/config.yml'
+)
+
+export const monologInfoMock = createMonologMock(
+  200, 'INFO',
+  'User authentication successful for user_id=42'
+)
+
+export const monologNoticeMock = createMonologMock(
+  250, 'NOTICE',
+  'Cache miss for key "user_profile_42", fetching from database'
+)
+
+export const monologWarningMock = createMonologMock(
+  300, 'WARNING',
+  'Deprecated method "getUsers()" called in UserController. Use "listUsers()" instead.'
+)
+
+export const monologErrorMock = createMonologMock(
+  400, 'ERROR',
+  'Failed to connect to Redis at 127.0.0.1:6379 - Connection refused'
+)
+
+export const monologCriticalMock = createMonologMock(
+  500, 'CRITICAL',
+  'Database connection pool exhausted. All 50 connections are in use. Queries are being rejected.'
+)
+
+export const monologAlertMock = createMonologMock(
+  550, 'ALERT',
+  'Payment gateway is not responding. All transactions are failing. Immediate action required.'
+)
+
+export const monologEmergencyMock = createMonologMock(
+  600, 'EMERGENCY',
+  'System is unusable. Disk /dev/sda1 is full (100%). All write operations are failing.'
+)

--- a/src/entities/monolog/types.ts
+++ b/src/entities/monolog/types.ts
@@ -2,6 +2,17 @@ import type { Source } from "@/shared/types";
 
 export type StatusCode = number; // TODO: update type
 
+export enum MonologLevel {
+  DEBUG = 100,
+  INFO = 200,
+  NOTICE = 250,
+  WARNING = 300,
+  ERROR = 400,
+  CRITICAL = 500,
+  ALERT = 550,
+  EMERGENCY = 600,
+}
+
 export interface Monolog {
   message: string,
   context: {

--- a/src/entities/monolog/ui/monolog-page/monolog-page.stories.ts
+++ b/src/entities/monolog/ui/monolog-page/monolog-page.stories.ts
@@ -1,6 +1,16 @@
 import type { Meta, StoryObj } from "@storybook/vue3-vite";
 import { useMonolog } from "../../lib";
-import { monologMock } from '../../mocks';
+import {
+  monologMock,
+  monologDebugMock,
+  monologInfoMock,
+  monologNoticeMock,
+  monologWarningMock,
+  monologErrorMock,
+  monologCriticalMock,
+  monologAlertMock,
+  monologEmergencyMock,
+} from '../../mocks';
 import Monolog from './monolog-page.vue';
 
 const { normalizeMonologEvent } = useMonolog();
@@ -13,9 +23,56 @@ export default {
   }
 } as Meta<typeof Monolog>;
 
-
 export const Default: StoryObj<typeof Monolog> = {
   args: {
     event: normalizeMonologEvent(monologMock),
+  }
+}
+
+export const Debug: StoryObj<typeof Monolog> = {
+  args: {
+    event: normalizeMonologEvent(monologDebugMock),
+  }
+}
+
+export const Info: StoryObj<typeof Monolog> = {
+  args: {
+    event: normalizeMonologEvent(monologInfoMock),
+  }
+}
+
+export const Notice: StoryObj<typeof Monolog> = {
+  args: {
+    event: normalizeMonologEvent(monologNoticeMock),
+  }
+}
+
+export const Warning: StoryObj<typeof Monolog> = {
+  args: {
+    event: normalizeMonologEvent(monologWarningMock),
+  }
+}
+
+export const Error: StoryObj<typeof Monolog> = {
+  args: {
+    event: normalizeMonologEvent(monologErrorMock),
+  }
+}
+
+export const Critical: StoryObj<typeof Monolog> = {
+  args: {
+    event: normalizeMonologEvent(monologCriticalMock),
+  }
+}
+
+export const Alert: StoryObj<typeof Monolog> = {
+  args: {
+    event: normalizeMonologEvent(monologAlertMock),
+  }
+}
+
+export const Emergency: StoryObj<typeof Monolog> = {
+  args: {
+    event: normalizeMonologEvent(monologEmergencyMock),
   }
 }

--- a/src/entities/monolog/ui/monolog-page/monolog-page.vue
+++ b/src/entities/monolog/ui/monolog-page/monolog-page.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { computed } from 'vue'
 import type { NormalizedEvent } from '@/shared/types'
 import {
   CodeSnippet,
@@ -7,13 +8,26 @@ import {
   EventDetailLayout,
   EventDetailSection
 } from '@/shared/ui'
+import { MonologLevel } from '../../types'
 import type { Monolog } from '../../types'
 
 type Props = {
   event: NormalizedEvent<Monolog>
 }
 
-defineProps<Props>()
+const props = defineProps<Props>()
+
+const levelBadgeClass = computed(() => {
+  const level = props.event.payload.level
+  if (level >= MonologLevel.EMERGENCY) return 'level-badge--emergency'
+  if (level >= MonologLevel.ALERT) return 'level-badge--alert'
+  if (level >= MonologLevel.CRITICAL) return 'level-badge--critical'
+  if (level >= MonologLevel.ERROR) return 'level-badge--error'
+  if (level >= MonologLevel.WARNING) return 'level-badge--warning'
+  if (level >= MonologLevel.NOTICE) return 'level-badge--notice'
+  if (level >= MonologLevel.INFO) return 'level-badge--info'
+  return 'level-badge--debug'
+})
 </script>
 
 <template>
@@ -21,6 +35,22 @@ defineProps<Props>()
     :title="`Channel: ${event.payload.channel}`"
     :date="event.date"
   >
+    <template #header>
+      <div class="monolog-page-header">
+        <div class="monolog-page-header__top">
+          <h2 class="monolog-page-header__title">
+            Channel: {{ event.payload.channel }}
+          </h2>
+          <span
+            class="level-badge"
+            :class="levelBadgeClass"
+          >
+            {{ event.payload.level_name }}
+          </span>
+        </div>
+      </div>
+    </template>
+
     <EventDetailSection title="Message">
       <CodeSnippet :code="event.payload.message" />
     </EventDetailSection>
@@ -80,3 +110,64 @@ defineProps<Props>()
     </EventDetailSection>
   </EventDetailLayout>
 </template>
+
+<style lang="scss" scoped>
+.monolog-page-header {
+  @apply flex flex-col gap-2;
+}
+
+.monolog-page-header__top {
+  @apply flex flex-col md:flex-row md:items-center gap-2;
+}
+
+.monolog-page-header__title {
+  @apply text-sm sm:text-base md:text-lg lg:text-xl font-semibold break-words;
+}
+
+.level-badge {
+  @apply inline-flex self-start items-center px-2.5 py-1 rounded text-xs font-bold uppercase tracking-wide;
+}
+
+.level-badge--debug {
+  @apply text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-600/50;
+}
+
+.level-badge--info {
+  @apply text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-500/10;
+}
+
+.level-badge--notice {
+  @apply text-cyan-600 dark:text-cyan-400 bg-cyan-50 dark:bg-cyan-500/10;
+}
+
+.level-badge--warning {
+  @apply text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-500/10;
+}
+
+.level-badge--error {
+  @apply text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-500/10;
+}
+
+.level-badge--critical {
+  @apply text-red-700 dark:text-red-300 bg-red-100 dark:bg-red-500/20;
+}
+
+.level-badge--alert {
+  @apply text-orange-600 dark:text-orange-400 bg-orange-50 dark:bg-orange-500/10;
+}
+
+.level-badge--emergency {
+  @apply text-red-700 dark:text-red-300 bg-red-100 dark:bg-red-500/20;
+  animation: pulse-emergency 2s ease-in-out infinite;
+}
+
+@keyframes pulse-emergency {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.6;
+  }
+}
+</style>

--- a/src/entities/monolog/ui/preview-card/preview-card.stories.ts
+++ b/src/entities/monolog/ui/preview-card/preview-card.stories.ts
@@ -1,6 +1,17 @@
 import type { Meta, StoryObj } from "@storybook/vue3-vite";
 import { useMonolog } from "../../lib";
-import { monologMock, monologExtendedMock } from '../../mocks'
+import {
+  monologMock,
+  monologExtendedMock,
+  monologDebugMock,
+  monologInfoMock,
+  monologNoticeMock,
+  monologWarningMock,
+  monologErrorMock,
+  monologCriticalMock,
+  monologAlertMock,
+  monologEmergencyMock,
+} from '../../mocks'
 import PreviewCard from './preview-card.vue';
 
 const { normalizeMonologEvent } = useMonolog();
@@ -32,5 +43,53 @@ export const WithOrigin: StoryObj<typeof PreviewCard> = {
 export const ComplexObject: StoryObj<typeof PreviewCard> = {
   args: {
     event: normalizeMonologEvent(monologExtendedMock),
+  }
+}
+
+export const Debug: StoryObj<typeof PreviewCard> = {
+  args: {
+    event: normalizeMonologEvent(monologDebugMock),
+  }
+}
+
+export const Info: StoryObj<typeof PreviewCard> = {
+  args: {
+    event: normalizeMonologEvent(monologInfoMock),
+  }
+}
+
+export const Notice: StoryObj<typeof PreviewCard> = {
+  args: {
+    event: normalizeMonologEvent(monologNoticeMock),
+  }
+}
+
+export const Warning: StoryObj<typeof PreviewCard> = {
+  args: {
+    event: normalizeMonologEvent(monologWarningMock),
+  }
+}
+
+export const Error: StoryObj<typeof PreviewCard> = {
+  args: {
+    event: normalizeMonologEvent(monologErrorMock),
+  }
+}
+
+export const Critical: StoryObj<typeof PreviewCard> = {
+  args: {
+    event: normalizeMonologEvent(monologCriticalMock),
+  }
+}
+
+export const Alert: StoryObj<typeof PreviewCard> = {
+  args: {
+    event: normalizeMonologEvent(monologAlertMock),
+  }
+}
+
+export const Emergency: StoryObj<typeof PreviewCard> = {
+  args: {
+    event: normalizeMonologEvent(monologEmergencyMock),
   }
 }

--- a/src/shared/types/events.ts
+++ b/src/shared/types/events.ts
@@ -20,6 +20,8 @@ export type Uuid = string;
 
 export type EventType = OneOfValues<typeof EventTypes>;
 
+export type LabelColor = 'gray' | 'blue' | 'cyan' | 'amber' | 'red' | 'orange' | 'green' | 'violet';
+
 export interface ServerEvent<T> {
   uuid: EventId,
   type: EventType | unknown,
@@ -33,7 +35,7 @@ export interface ServerEvent<T> {
 export interface NormalizedEvent<T> {
   id: EventId,
   type: EventType | 'unknown',
-  labels: (string | { title: string, value: string, context: string })[],
+  labels: (string | { title: string, value: string, context: string } | { text: string, color: LabelColor })[],
   origin: object | null,
   serverName: string,
   date: Date | null,

--- a/src/shared/ui/preview-card/preview-card-header.vue
+++ b/src/shared/ui/preview-card/preview-card-header.vue
@@ -75,6 +75,12 @@ const copyEvent = () => emit('copy', true)
 const lockEvent = () => emit('lock', true)
 
 const isVisibleTags = computed(() => props.labels.length > 0)
+
+const isColoredLabel = (label: unknown): label is { text: string; color: string } =>
+  typeof label === 'object' && label !== null && 'text' in label && 'color' in label
+
+const isKvLabel = (label: unknown): label is { title: string; value: string; context: string } =>
+  typeof label === 'object' && label !== null && 'title' in label && 'value' in label
 </script>
 
 <template>
@@ -101,8 +107,8 @@ const isVisibleTags = computed(() => props.labels.length > 0)
       <!-- Labels -->
       <template v-if="isVisibleTags">
         <template
-          v-for="label in labels"
-          :key="label"
+          v-for="(label, idx) in labels"
+          :key="idx"
         >
           <span
             v-if="isString(label)"
@@ -112,7 +118,15 @@ const isVisibleTags = computed(() => props.labels.length > 0)
           </span>
 
           <span
-            v-if="!isString(label)"
+            v-else-if="isColoredLabel(label)"
+            class="pc-header__label"
+            :class="`pc-header__label--${label.color}`"
+          >
+            <HighlightText :text="label.text" />
+          </span>
+
+          <span
+            v-else-if="isKvLabel(label)"
             class="pc-header__label pc-header__label--kv"
             :title="label.context"
           >
@@ -350,6 +364,76 @@ $typeColors: (
   @apply inline-flex items-center px-1.5 py-0.5 rounded;
   @apply text-2xs font-medium;
   @apply bg-gray-100 dark:bg-gray-600/50 text-gray-600 dark:text-gray-300;
+}
+
+/* Colored label variants
+   Tailwind safelist:
+   'text-gray-500 dark:text-gray-400'
+   'text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-500/10'
+   'text-cyan-600 dark:text-cyan-400 bg-cyan-50 dark:bg-cyan-500/10'
+   'text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-500/10'
+   'text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-500/10'
+   'text-orange-600 dark:text-orange-400 bg-orange-50 dark:bg-orange-500/10'
+   'text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-500/10'
+   'text-violet-600 dark:text-violet-400 bg-violet-50 dark:bg-violet-500/10' */
+
+$labelColors: (
+  'gray': (
+    'text': 'gray-500',
+    'text-dark': 'gray-400',
+    'bg': 'gray-100',
+    'bg-dark': 'gray-600/50'
+  ),
+  'blue': (
+    'text': 'blue-600',
+    'text-dark': 'blue-400',
+    'bg': 'blue-50',
+    'bg-dark': 'blue-500/10'
+  ),
+  'cyan': (
+    'text': 'cyan-600',
+    'text-dark': 'cyan-400',
+    'bg': 'cyan-50',
+    'bg-dark': 'cyan-500/10'
+  ),
+  'amber': (
+    'text': 'amber-600',
+    'text-dark': 'amber-400',
+    'bg': 'amber-50',
+    'bg-dark': 'amber-500/10'
+  ),
+  'red': (
+    'text': 'red-600',
+    'text-dark': 'red-400',
+    'bg': 'red-50',
+    'bg-dark': 'red-500/10'
+  ),
+  'orange': (
+    'text': 'orange-600',
+    'text-dark': 'orange-400',
+    'bg': 'orange-50',
+    'bg-dark': 'orange-500/10'
+  ),
+  'green': (
+    'text': 'green-600',
+    'text-dark': 'green-400',
+    'bg': 'green-50',
+    'bg-dark': 'green-500/10'
+  ),
+  'violet': (
+    'text': 'violet-600',
+    'text-dark': 'violet-400',
+    'bg': 'violet-50',
+    'bg-dark': 'violet-500/10'
+  )
+);
+
+@each $color, $tokens in $labelColors {
+  .pc-header__label--#{$color} {
+    @apply text-#{map-get($tokens, 'text')} dark:text-#{map-get($tokens, 'text-dark')};
+    @apply bg-#{map-get($tokens, 'bg')} dark:bg-#{map-get($tokens, 'bg-dark')};
+    @apply font-semibold;
+  }
 }
 
 .pc-header__label--kv {


### PR DESCRIPTION
## Summary
- Added colored level labels (DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL, ALERT, EMERGENCY) to Monolog event headers in preview cards and detail pages
- Introduced reusable `LabelColor` type and colored label rendering in shared `PreviewCardHeader` component — can be used by other event types too
- Added `MonologLevel` enum and level-to-color mapping in the normalizer
- Added Storybook stories for all 8 log levels (both PreviewCard and MonologPage)

## Color mapping
| Level | Color |
|-------|-------|
| DEBUG | gray |
| INFO | blue |
| NOTICE | cyan |
| WARNING | amber |
| ERROR | red |
| CRITICAL | red |
| ALERT | orange |
| EMERGENCY | red (pulsing) |

## Test plan
- [x] Open Storybook, check `Entities/Monolog/PreviewCard` — all 8 level variants display correct colored labels
- [x] Open Storybook, check `Entities/Monolog/MonologPage` — all 8 level variants display correct level badge in header
- [x] Verify dark mode renders correctly for all color variants
- [x] Verify existing event types (sentry, smtp, etc.) are not affected by the shared header changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)