### PR TITLE
fix(http-dump): file attachment download not working

### DIFF
--- a/src/entities/http-dump/ui/http-dump-page/http-dump-page.vue
+++ b/src/entities/http-dump/ui/http-dump-page/http-dump-page.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { computed } from 'vue'
-import type { NormalizedEvent } from '@/shared/types'
+import { useAttachments } from '@/shared/lib/io'
+import type { NormalizedEvent, Attachment } from '@/shared/types'
 import {
   TableBase,
   TableBaseRow,
@@ -16,6 +17,11 @@ type Props = {
 }
 
 const props = defineProps<Props>()
+
+const { calcDownloadLink } = useAttachments('http-dump')
+
+const calcDownloadUrl = (attachmentId: Attachment['uuid']) =>
+  calcDownloadLink(props.event.id, attachmentId)
 
 const uri = computed(() => decodeURI(props.event.payload?.request?.uri))
 
@@ -214,6 +220,7 @@ const rawHttp = computed(() => {
           :key="file.uuid"
           :event-id="event.id"
           :attachment="file"
+          :download-url="calcDownloadUrl(file.uuid)"
         />
       </div>
     </EventDetailSection>

--- a/src/shared/lib/io/use-attachments.ts
+++ b/src/shared/lib/io/use-attachments.ts
@@ -3,17 +3,19 @@ import {useProfileStore} from "../../stores";
 import type { EventId, Attachment } from "../../types";
 import { REST_API_URL } from "./constants";
 
-type TUseAttachments = () => {
+type EventModule = 'smtp' | 'http-dump'
+
+type TUseAttachments = (module?: EventModule) => {
   getAttachments: (id: EventId) => Promise<Attachment[]>
   calcDownloadLink: (id: EventId, attachmentId: string) => string
 }
 
-export const useAttachments: TUseAttachments = () => {
+export const useAttachments: TUseAttachments = (module: EventModule = 'smtp') => {
   const { token } = storeToRefs(useProfileStore())
 
   const headers = {"X-Auth-Token": token.value }
 
-  const calcDownloadLink = (id: EventId, attachmentId?: string): string => `${REST_API_URL}/api/smtp/${id}/attachments${attachmentId ? `/${attachmentId}` : ''}`
+  const calcDownloadLink = (id: EventId, attachmentId?: string): string => `${REST_API_URL}/api/${module}/${id}/attachments${attachmentId ? `/${attachmentId}` : ''}`
 
   const getAttachments = (id: EventId) => fetch(calcDownloadLink(id), { headers })
     .then((response) => response.json())


### PR DESCRIPTION
## Summary
- **Bug**: `http-dump-page.vue` rendered `FileAttachment` without the `:download-url` prop, so attachments appeared as non-clickable `<div>` elements instead of download links
- **Fix**: Made `useAttachments()` accept a `module` parameter (`'smtp' | 'http-dump'`) to generate correct API endpoint URLs, and passed `download-url` to `FileAttachment` in the HTTP dump detail page
- SMTP is unaffected — `useAttachments()` defaults to `'smtp'`

## Test plan
- [x] Open an HTTP dump event with file attachments — attachments should now be clickable download links
- [x] Verify SMTP attachments still work (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)