### PR TITLE
fix: prevent sidebar width flash on route navigation

### DIFF
--- a/src/widgets/ui/layout-sidebar/layout-sidebar.vue
+++ b/src/widgets/ui/layout-sidebar/layout-sidebar.vue
@@ -50,9 +50,13 @@ const applySidebarClass = (collapsed: boolean) => {
 // Apply on init
 applySidebarClass(isCollapsed.value)
 
-// Clean up global class when component is destroyed (e.g. Storybook story switch)
+// Clean up global class only in Storybook (prevents class leak between stories).
+// In production, sidebar is always present so cleanup during route navigation
+// would cause a width flash (class removed before new sidebar re-adds it).
 onUnmounted(() => {
-  document?.documentElement?.classList?.remove('sidebar-collapsed')
+  if (import.meta.env.STORYBOOK) {
+    document?.documentElement?.classList?.remove('sidebar-collapsed')
+  }
 })
 
 const toggleCollapse = () => {


### PR DESCRIPTION
## What
Fixes the sidebar expanding to 14rem (full width) when navigating to a detail page, even though it should remain collapsed at 4rem.

## Why
The `onUnmounted` hook in `LayoutSidebar` unconditionally removed the `sidebar-collapsed` class from `<html>`. During route transitions, the old sidebar unmounts (removes class) before the new one mounts (re-adds it), causing the expanded width CSS (`xl:w-56`) to apply permanently.

## How
- `onUnmounted` cleanup now only runs in Storybook (`import.meta.env.STORYBOOK`), where it prevents class leaks between stories
- In production the sidebar is always present across pages, so the class persists correctly through navigation

## Testing
- Set sidebar to collapsed state
- Navigate between pages (e.g. click an SMTP event to go to detail view)
- Verify sidebar stays collapsed at 4rem width, no flash to 14rem