### PR TITLE
feat: add proxy request support to http-dump UI

### DIFF
--- a/src/entities/http-dump/lib/use-http-dump/index.ts
+++ b/src/entities/http-dump/lib/use-http-dump/index.ts
@@ -1,2 +1,2 @@
 export * from "./use-http-dump";
-
+export * from "./use-http-dump-event";

--- a/src/entities/http-dump/lib/use-http-dump/normalize-http-dump-event.ts
+++ b/src/entities/http-dump/lib/use-http-dump/normalize-http-dump-event.ts
@@ -3,12 +3,21 @@ import {type ServerEvent, type NormalizedEvent, type Attachment, EventTypes} fro
 import type {HttpDump, HttpDumpServer} from "../../types";
 
 export const normalizeHttpDumpEvent = (event: ServerEvent<HttpDumpServer>): NormalizedEvent<HttpDump> => {
+  const isProxy = !!event.payload.proxy;
+  const host = event.payload.host;
+  const uri = event.payload.request.uri;
+
+  // Build full URL for proxy requests (host includes port)
+  const fullUrl = isProxy
+    ? `${host}${uri}`
+    : uri;
+
   const normalizedEvent: NormalizedEvent<HttpDump> = {
     id: event.uuid,
     type: EventTypes.HttpDump,
     labels: [EventTypes.HttpDump],
-    origin: {uri: event.payload.request.uri},
-    serverName: event.payload.host,
+    origin: {uri: fullUrl},
+    serverName: host,
     date: event.timestamp ? new Date(event.timestamp * 1000) : null,
     payload: {
       ...event.payload,
@@ -25,11 +34,23 @@ export const normalizeHttpDumpEvent = (event: ServerEvent<HttpDumpServer>): Norm
     }
   };
 
+  if (isProxy) {
+    normalizedEvent.labels.push({text: 'proxy', color: 'violet'});
+  }
+
+  if (event.payload.response?.status_code) {
+    const code = event.payload.response.status_code;
+    const color = code >= 500 ? 'red' : code >= 400 ? 'orange' : code >= 300 ? 'blue' : 'green';
+    normalizedEvent.labels.push({text: String(code), color});
+  }
+
+  if (event.payload.duration_ms != null) {
+    normalizedEvent.labels.push(`${event.payload.duration_ms}ms`);
+  }
+
   if (normalizedEvent.date) {
     normalizedEvent.labels.unshift(moment(normalizedEvent.date).format("HH:mm:ss"));
   }
 
   return normalizedEvent;
 }
-
-

--- a/src/entities/http-dump/lib/use-http-dump/use-http-dump-event.ts
+++ b/src/entities/http-dump/lib/use-http-dump/use-http-dump-event.ts
@@ -1,0 +1,230 @@
+import { computed, type Ref } from 'vue'
+import type { NormalizedEvent } from '@/shared/types'
+import type { HttpDump } from '../../types'
+
+export const useHttpDumpEvent = (event: Ref<NormalizedEvent<HttpDump>>) => {
+  const isProxy = computed(() => !!event.value.payload.proxy)
+  const method = computed(() => event.value.payload.request.method)
+
+  const uri = computed(() => {
+    const rawUri = decodeURI(event.value.payload.request.uri)
+    if (isProxy.value) {
+      return `${event.value.payload.host}${rawUri}`
+    }
+    return rawUri
+  })
+
+  const host = computed(() => {
+    const h = event.value.payload.request.headers?.host
+    if (!h) return null
+    return Array.isArray(h) ? h[0] : h
+  })
+
+  const contentType = computed(() => {
+    const ct =
+      event.value.payload.request.headers?.['content-type'] ||
+      event.value.payload.request.headers?.['Content-Type']
+    if (!ct) return null
+    const val = Array.isArray(ct) ? ct[0] : ct
+    return val?.split(';')[0]?.trim() || null
+  })
+
+  const statusCode = computed(() => event.value.payload.response?.status_code)
+  const durationMs = computed(() => event.value.payload.duration_ms)
+  const proxyError = computed(() => event.value.payload.error)
+
+  const methodColor = computed(() => {
+    const m = method.value?.toUpperCase()
+    if (m === 'GET') return 'text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-500/10'
+    if (m === 'POST') return 'text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-500/10'
+    if (m === 'PUT' || m === 'PATCH')
+      return 'text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-500/10'
+    if (m === 'DELETE') return 'text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-500/10'
+    return 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-500/10'
+  })
+
+  const statusColor = computed(() => {
+    const code = statusCode.value
+    if (!code) return ''
+    if (code >= 500) return 'text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-500/10'
+    if (code >= 400) return 'text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-500/10'
+    if (code >= 300) return 'text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-500/10'
+    return 'text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-500/10'
+  })
+
+  const borderStatusClass = computed(() => {
+    if (!isProxy.value || !statusCode.value) return 'border-l-transparent'
+    const code = statusCode.value
+    if (code >= 500) return 'border-l-red-500'
+    if (code >= 400) return 'border-l-amber-400'
+    if (code >= 300) return 'border-l-blue-400'
+    return 'border-l-green-500'
+  })
+
+  const queryCount = computed(() => Object.keys(event.value.payload.request.query || {}).length)
+  const headerCount = computed(() => Object.keys(event.value.payload.request.headers || {}).length)
+  const hasBody = computed(() => (event.value.payload.request.body?.length || 0) > 0)
+
+  const bodySize = computed(() => {
+    const len = event.value.payload.request.body?.length || 0
+    if (!len) return null
+    if (len < 1024) return `${len} B`
+    if (len < 1024 * 1024) return `${(len / 1024).toFixed(1)} KB`
+    return `${(len / (1024 * 1024)).toFixed(1)} MB`
+  })
+
+  const curlCommand = computed(() => {
+    const req = event.value.payload.request
+    let curl = `curl -X ${req.method}`
+
+    if (isProxy.value) {
+      curl += ` '${event.value.payload.host}${req.uri}'`
+    } else if (host.value) {
+      curl += ` '${host.value}${req.uri}'`
+    } else {
+      curl += ` '${req.uri}'`
+    }
+
+    const headers = req.headers || {}
+    for (const [key, val] of Object.entries(headers)) {
+      if (key.toLowerCase() === 'host') continue
+      const v = Array.isArray(val) ? val[0] : val
+      curl += ` \\\n  -H '${key}: ${v}'`
+    }
+
+    if (req.body) {
+      curl += ` \\\n  -d '${req.body.replace(/'/g, "'\\''")}'`
+    }
+
+    return curl
+  })
+
+  const rawHttp = computed(() => {
+    const req = event.value.payload.request
+    let raw = `${req.method} ${req.uri} HTTP/1.1\n`
+
+    const headers = req.headers || {}
+    for (const [key, val] of Object.entries(headers)) {
+      const v = Array.isArray(val) ? val[0] : val
+      raw += `${key}: ${v}\n`
+    }
+
+    if (req.body) {
+      raw += `\n${req.body}`
+    }
+
+    return raw
+  })
+
+  // Response helpers
+  const response = computed(() => event.value.payload.response)
+  const hasResponse = computed(() => !!response.value)
+
+  const hasPostData = computed(
+    () => event.value.payload.request.post && Object.keys(event.value.payload.request.post).length > 0,
+  )
+
+  const hasQuery = computed(
+    () => event.value.payload.request.query && Object.keys(event.value.payload.request.query).length > 0,
+  )
+
+  const hasHeaders = computed(() => Object.keys(event.value.payload.request.headers || {}).length > 0)
+
+  const hasCookies = computed(
+    () => event.value.payload.request.cookies && Object.keys(event.value.payload.request.cookies).length > 0,
+  )
+
+  const hasAttachments = computed(
+    () => event.value.payload.request.files && event.value.payload.request.files.length > 0,
+  )
+
+  const responseContentType = computed(() => {
+    if (!response.value?.headers) return null
+    const ct = response.value.headers['content-type'] || response.value.headers['Content-Type']
+    if (!ct) return null
+    const val = Array.isArray(ct) ? ct[0] : ct
+    return val?.split(';')[0]?.trim() || null
+  })
+
+  const responseBodyLanguage = computed(() => {
+    const ct = responseContentType.value
+    if (!ct) return 'plaintext'
+    if (ct.includes('json')) return 'json'
+    if (ct.includes('xml') || ct.includes('svg')) return 'xml'
+    if (ct.includes('html')) return 'html'
+    if (ct.includes('css')) return 'css'
+    if (ct.includes('javascript')) return 'javascript'
+    return 'plaintext'
+  })
+
+  const responseBody = computed(() => {
+    const body = response.value?.body
+    if (!body) return null
+    if (responseBodyLanguage.value === 'json') {
+      try {
+        return JSON.stringify(JSON.parse(body), null, 2)
+      } catch {
+        return body
+      }
+    }
+    return body
+  })
+
+  const isBinaryResponse = computed(() => {
+    const ct = responseContentType.value
+    if (!ct) return false
+    return (
+      ct.startsWith('image/') ||
+      ct.startsWith('audio/') ||
+      ct.startsWith('video/') ||
+      ct.includes('octet-stream') ||
+      ct.includes('zip') ||
+      ct.includes('gzip') ||
+      ct.includes('tar') ||
+      ct.includes('pdf')
+    )
+  })
+
+  const responseBodySize = computed(() => {
+    const len = response.value?.body?.length || 0
+    if (!len) return null
+    if (len < 1024) return `${len} B`
+    if (len < 1024 * 1024) return `${(len / 1024).toFixed(1)} KB`
+    return `${(len / (1024 * 1024)).toFixed(1)} MB`
+  })
+
+  const hasResponseHeaders = computed(() => Object.keys(response.value?.headers || {}).length > 0)
+
+  return {
+    isProxy,
+    method,
+    uri,
+    host,
+    contentType,
+    statusCode,
+    durationMs,
+    proxyError,
+    methodColor,
+    statusColor,
+    borderStatusClass,
+    queryCount,
+    headerCount,
+    hasBody,
+    bodySize,
+    curlCommand,
+    rawHttp,
+    response,
+    hasResponse,
+    hasPostData,
+    hasQuery,
+    hasHeaders,
+    hasCookies,
+    hasAttachments,
+    responseContentType,
+    responseBodyLanguage,
+    responseBody,
+    isBinaryResponse,
+    responseBodySize,
+    hasResponseHeaders,
+  }
+}

--- a/src/entities/http-dump/mocks/http-dump-proxy-4xx.json
+++ b/src/entities/http-dump/mocks/http-dump-proxy-4xx.json
@@ -1,0 +1,34 @@
+{
+  "uuid": "f6a7b8c9-abcd-4f01-e234-666666666666",
+  "type": "http-dump",
+  "payload": {
+    "received_at": "2026-04-04 12:05:10",
+    "host": "api.stripe.com:443",
+    "proxy": true,
+    "duration_ms": 156,
+    "request": {
+      "method": "POST",
+      "uri": "/v1/charges",
+      "headers": {
+        "User-Agent": ["GuzzleHttp/7"],
+        "Content-Type": ["application/x-www-form-urlencoded"],
+        "Authorization": ["Bearer sk_test_FAKE_KEY_FOR_MOCK_DATA_ONLY"]
+      },
+      "body": "amount=2000&currency=usd&source=tok_invalid",
+      "query": {},
+      "post": {},
+      "cookies": {},
+      "files": []
+    },
+    "response": {
+      "status_code": 402,
+      "headers": {
+        "Content-Type": ["application/json"],
+        "Request-Id": ["req_abc123"]
+      },
+      "body": "{\n  \"error\": {\n    \"code\": \"card_declined\",\n    \"doc_url\": \"https://stripe.com/docs/error-codes/card-declined\",\n    \"message\": \"Your card was declined.\",\n    \"param\": \"source\",\n    \"type\": \"card_error\"\n  }\n}"
+    }
+  },
+  "timestamp": 1743764710,
+  "project": null
+}

--- a/src/entities/http-dump/mocks/http-dump-proxy-binary.json
+++ b/src/entities/http-dump/mocks/http-dump-proxy-binary.json
@@ -1,0 +1,33 @@
+{
+  "uuid": "e5f6a7b8-9abc-4ef0-d123-555555555555",
+  "type": "http-dump",
+  "payload": {
+    "received_at": "2026-04-04 12:04:00",
+    "host": "httpbin.org:443",
+    "proxy": true,
+    "duration_ms": 890,
+    "request": {
+      "method": "GET",
+      "uri": "/image/png",
+      "headers": {
+        "User-Agent": ["GuzzleHttp/7"],
+        "Accept": ["image/png"]
+      },
+      "body": "",
+      "query": {},
+      "post": {},
+      "cookies": {},
+      "files": []
+    },
+    "response": {
+      "status_code": 200,
+      "headers": {
+        "Content-Type": ["image/png"],
+        "Content-Length": ["8090"]
+      },
+      "body": "[binary data, 8090 bytes]"
+    }
+  },
+  "timestamp": 1743764640,
+  "project": null
+}

--- a/src/entities/http-dump/mocks/http-dump-proxy-error.json
+++ b/src/entities/http-dump/mocks/http-dump-proxy-error.json
@@ -1,0 +1,27 @@
+{
+  "uuid": "c3d4e5f6-789a-4cde-bf01-333333333333",
+  "type": "http-dump",
+  "payload": {
+    "received_at": "2026-04-04 12:02:30",
+    "host": "api.unreachable-service.example:443",
+    "proxy": true,
+    "duration_ms": 5002,
+    "error": "dial tcp: lookup api.unreachable-service.example: no such host",
+    "request": {
+      "method": "POST",
+      "uri": "/v1/webhook",
+      "headers": {
+        "User-Agent": ["GuzzleHttp/7"],
+        "Content-Type": ["application/json"],
+        "Authorization": ["Bearer sk_test_FAKE_KEY_FOR_MOCK_DATA_ONLY"]
+      },
+      "body": "{\"event\":\"order.created\",\"data\":{\"order_id\":1234,\"amount\":49.99}}",
+      "query": {},
+      "post": {},
+      "cookies": {},
+      "files": []
+    }
+  },
+  "timestamp": 1743764550,
+  "project": null
+}

--- a/src/entities/http-dump/mocks/http-dump-proxy-html.json
+++ b/src/entities/http-dump/mocks/http-dump-proxy-html.json
@@ -1,0 +1,34 @@
+{
+  "uuid": "b2c3d4e5-6789-4bcd-aef0-222222222222",
+  "type": "http-dump",
+  "payload": {
+    "received_at": "2026-04-04 12:01:15",
+    "host": "httpbin.org:443",
+    "proxy": true,
+    "duration_ms": 578,
+    "request": {
+      "method": "GET",
+      "uri": "/html",
+      "headers": {
+        "User-Agent": ["GuzzleHttp/7"],
+        "Accept": ["text/html,application/xhtml+xml"]
+      },
+      "body": "",
+      "query": {},
+      "post": {},
+      "cookies": {},
+      "files": []
+    },
+    "response": {
+      "status_code": 200,
+      "headers": {
+        "Content-Type": ["text/html; charset=utf-8"],
+        "Content-Length": ["3741"],
+        "Server": ["gunicorn/19.9.0"]
+      },
+      "body": "<!DOCTYPE html>\n<html>\n<head>\n  <title>Herman Melville - Moby Dick</title>\n  <style>\n    body { font-family: Georgia, serif; max-width: 600px; margin: 2rem auto; padding: 0 1rem; color: #333; }\n    h1 { color: #1a1a2e; border-bottom: 2px solid #16213e; padding-bottom: 0.5rem; }\n    p { line-height: 1.8; text-align: justify; }\n  </style>\n</head>\n<body>\n  <h1>Herman Melville - Moby Dick</h1>\n  <p>Availing himself of the mild, summer-cool weather that now reigned in these latitudes, and in preparation for the peculiarly active pursuits shortly to be anticipated, Perth, the begrimed, blistered old blacksmith, had not removed his portable forge to the hold again, after concluding his contributory work for Ahab's leg, but still retained it on deck, fast lashed to ringbolts by the foremast; being now almost incessantly invoked with the numberless necdful little jobs that daily crop up in a ship.</p>\n</body>\n</html>"
+    }
+  },
+  "timestamp": 1743764475,
+  "project": null
+}

--- a/src/entities/http-dump/mocks/http-dump-proxy-json.json
+++ b/src/entities/http-dump/mocks/http-dump-proxy-json.json
@@ -1,0 +1,36 @@
+{
+  "uuid": "a1b2c3d4-5678-4abc-9def-111111111111",
+  "type": "http-dump",
+  "payload": {
+    "received_at": "2026-04-04 12:00:00",
+    "host": "jsonplaceholder.typicode.com:443",
+    "proxy": true,
+    "duration_ms": 342,
+    "request": {
+      "method": "POST",
+      "uri": "/posts",
+      "headers": {
+        "User-Agent": ["GuzzleHttp/7"],
+        "Content-Type": ["application/json"],
+        "Accept": ["application/json"]
+      },
+      "body": "{\"title\":\"Buggregator proxy test\",\"body\":\"Testing the HTTP proxy capture\",\"userId\":1}",
+      "query": {},
+      "post": {},
+      "cookies": {},
+      "files": []
+    },
+    "response": {
+      "status_code": 201,
+      "headers": {
+        "Content-Type": ["application/json; charset=utf-8"],
+        "X-Powered-By": ["Express"],
+        "Cache-Control": ["no-cache"],
+        "Content-Length": ["121"]
+      },
+      "body": "{\n  \"title\": \"Buggregator proxy test\",\n  \"body\": \"Testing the HTTP proxy capture\",\n  \"userId\": 1,\n  \"id\": 101\n}"
+    }
+  },
+  "timestamp": 1743764400,
+  "project": null
+}

--- a/src/entities/http-dump/mocks/http-dump-proxy-xml.json
+++ b/src/entities/http-dump/mocks/http-dump-proxy-xml.json
@@ -1,0 +1,33 @@
+{
+  "uuid": "d4e5f6a7-89ab-4def-c012-444444444444",
+  "type": "http-dump",
+  "payload": {
+    "received_at": "2026-04-04 12:03:45",
+    "host": "httpbin.org:443",
+    "proxy": true,
+    "duration_ms": 215,
+    "request": {
+      "method": "GET",
+      "uri": "/xml",
+      "headers": {
+        "User-Agent": ["GuzzleHttp/7"],
+        "Accept": ["application/xml"]
+      },
+      "body": "",
+      "query": {},
+      "post": {},
+      "cookies": {},
+      "files": []
+    },
+    "response": {
+      "status_code": 200,
+      "headers": {
+        "Content-Type": ["application/xml"],
+        "Content-Length": ["522"]
+      },
+      "body": "<?xml version='1.0' encoding='us-ascii'?>\n<slideshow\n    title=\"Sample Slide Show\"\n    date=\"Date of publication\"\n    author=\"Yours Truly\">\n  <slide type=\"all\">\n    <title>Wake up to WonderWidgets!</title>\n  </slide>\n  <slide type=\"all\">\n    <title>Overview</title>\n    <item>Why <em>WonderWidgets</em> are great</item>\n    <item/>\n    <item>Who <em>buys</em> WonderWidgets</item>\n  </slide>\n</slideshow>"
+    }
+  },
+  "timestamp": 1743764625,
+  "project": null
+}

--- a/src/entities/http-dump/mocks/index.ts
+++ b/src/entities/http-dump/mocks/index.ts
@@ -1,7 +1,19 @@
+import httpDumpProxy4xxMock from './http-dump-proxy-4xx.json';
+import httpDumpProxyBinaryMock from './http-dump-proxy-binary.json';
+import httpDumpProxyErrorMock from './http-dump-proxy-error.json';
+import httpDumpProxyHtmlMock from './http-dump-proxy-html.json';
+import httpDumpProxyJsonMock from './http-dump-proxy-json.json';
+import httpDumpProxyXmlMock from './http-dump-proxy-xml.json';
 import httpDumpPdfMock from './http-dump-with-pdf.json';
 import httpDumpMock from './http-dump.json';
 
 export {
   httpDumpMock,
-  httpDumpPdfMock
+  httpDumpPdfMock,
+  httpDumpProxyJsonMock,
+  httpDumpProxyHtmlMock,
+  httpDumpProxyErrorMock,
+  httpDumpProxyXmlMock,
+  httpDumpProxyBinaryMock,
+  httpDumpProxy4xxMock,
 }

--- a/src/entities/http-dump/types.ts
+++ b/src/entities/http-dump/types.ts
@@ -1,8 +1,18 @@
 import type {Attachment, Uuid} from "@/shared/types";
 
+export interface HttpDumpResponse {
+  status_code: number,
+  headers: Record<string, string[]>,
+  body: string,
+}
+
 export interface HttpDumpServer {
   received_at: string,
   host: string,
+  proxy?: boolean,
+  duration_ms?: number,
+  error?: string,
+  response?: HttpDumpResponse,
   request: {
     method: string,
     uri: string,

--- a/src/entities/http-dump/ui/http-body-view/http-body-view-toggle.vue
+++ b/src/entities/http-dump/ui/http-body-view/http-body-view-toggle.vue
@@ -1,0 +1,45 @@
+<script lang="ts" setup>
+type Props = {
+  modes: string[]
+  active: string
+}
+
+defineProps<Props>()
+const emit = defineEmits<{ 'update:active': [value: string] }>()
+</script>
+
+<template>
+  <div class="body-toggle">
+    <button
+      v-for="mode in modes"
+      :key="mode"
+      class="body-toggle__btn"
+      :class="{ 'body-toggle__btn--active': active === mode }"
+      @click="emit('update:active', mode)"
+    >
+      {{ mode }}
+    </button>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.body-toggle {
+  @apply flex items-center rounded overflow-hidden;
+  @apply border border-gray-200 dark:border-gray-700;
+}
+
+.body-toggle__btn {
+  @apply px-2 py-0.5 text-2xs font-medium cursor-pointer capitalize;
+  @apply text-gray-500 dark:text-gray-400;
+  @apply hover:text-gray-700 dark:hover:text-gray-200;
+  @apply transition-colors duration-150;
+
+  &:not(:last-child) {
+    @apply border-r border-gray-200 dark:border-gray-700;
+  }
+}
+
+.body-toggle__btn--active {
+  @apply bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200;
+}
+</style>

--- a/src/entities/http-dump/ui/http-body-view/http-body-view.stories.ts
+++ b/src/entities/http-dump/ui/http-body-view/http-body-view.stories.ts
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import HttpBodyView from './http-body-view.vue'
+
+export default {
+  title: 'Entities/HttpDump/HttpBodyView',
+  component: HttpBodyView,
+} as Meta<typeof HttpBodyView>
+
+export const JsonBody: StoryObj<typeof HttpBodyView> = {
+  args: {
+    body: JSON.stringify({
+      id: 101,
+      title: 'Buggregator proxy test',
+      user: { id: 42, name: 'John Doe', email: 'john@example.com' },
+      tags: ['admin', 'developer'],
+    }),
+    language: 'json',
+    contentType: 'application/json',
+    size: '234 B',
+  },
+}
+
+export const EmptyJsonObject: StoryObj<typeof HttpBodyView> = {
+  args: {
+    body: '{}',
+    language: 'json',
+    contentType: 'application/json',
+    size: '2 B',
+  },
+}
+
+export const HtmlBody: StoryObj<typeof HttpBodyView> = {
+  args: {
+    body: '<!DOCTYPE html>\n<html>\n<head><title>Test</title>\n<style>body { font-family: sans-serif; padding: 2rem; }</style>\n</head>\n<body>\n<h1>Hello from Buggregator</h1>\n<p>This is an HTML response preview.</p>\n</body>\n</html>',
+    language: 'html',
+    contentType: 'text/html',
+    size: '210 B',
+  },
+}
+
+export const XmlBody: StoryObj<typeof HttpBodyView> = {
+  args: {
+    body: '<?xml version="1.0" encoding="UTF-8"?>\n<response>\n  <status>ok</status>\n  <data>\n    <item id="1">Widget</item>\n    <item id="2">Gadget</item>\n  </data>\n</response>',
+    language: 'xml',
+    contentType: 'application/xml',
+    size: '180 B',
+  },
+}
+
+export const PlainTextBody: StoryObj<typeof HttpBodyView> = {
+  args: {
+    body: 'OK',
+    language: 'plaintext',
+    contentType: 'text/plain',
+    size: '2 B',
+  },
+}
+
+export const LargeJsonBody: StoryObj<typeof HttpBodyView> = {
+  args: {
+    body: JSON.stringify({
+      data: Array.from({ length: 20 }, (_, i) => ({
+        id: i + 1,
+        name: `Item ${i + 1}`,
+        description: 'A long description string that demonstrates how the tree view handles moderately sized text content across multiple entries in a large JSON payload',
+        nested: { level1: { level2: { value: Math.random() } } },
+      })),
+    }),
+    language: 'json',
+    contentType: 'application/json',
+    size: '4.2 KB',
+  },
+}

--- a/src/entities/http-dump/ui/http-body-view/http-body-view.vue
+++ b/src/entities/http-dump/ui/http-body-view/http-body-view.vue
@@ -1,0 +1,145 @@
+<script lang="ts" setup>
+import { computed, ref, toRef } from 'vue'
+import { CodeSnippet } from '@/shared/ui'
+import { JsonTreeView, useJsonTree } from '@/shared/ui/json-tree-view'
+
+type Props = {
+  body: string | null
+  language: string
+  contentType?: string
+  size?: string
+}
+
+const props = defineProps<Props>()
+
+const { parsed, isJson } = useJsonTree(toRef(props, 'body'))
+
+type ViewMode = 'raw' | 'pretty' | 'tree'
+type HtmlMode = 'preview' | 'source'
+
+const viewMode = ref<ViewMode>(isJson.value ? 'tree' : 'pretty')
+const htmlMode = ref<HtmlMode>('preview')
+
+const prettyJson = computed(() => {
+  if (!props.body || !isJson.value) return props.body
+  try {
+    return JSON.stringify(JSON.parse(props.body), null, 2)
+  } catch {
+    return props.body
+  }
+})
+
+const isHtml = computed(() => props.language === 'html')
+
+const openHtmlPreview = () => {
+  if (!props.body) return
+  const win = window.open('about:blank')
+  if (win) {
+    win.document.write(props.body)
+    win.document.close()
+  }
+}
+
+defineExpose({ viewMode, htmlMode, isJson, isHtml })
+</script>
+
+<template>
+  <div class="http-body-view">
+    <!-- Header with meta + toggle (shown when no external #toggle slot) -->
+    <div
+      v-if="contentType || size"
+      class="http-body-view__header"
+    >
+      <div class="http-body-view__meta">
+        <span
+          v-if="contentType"
+          class="http-body-view__tag"
+        >{{ contentType }}</span>
+        <span
+          v-if="size"
+          class="http-body-view__tag"
+        >{{ size }}</span>
+      </div>
+    </div>
+
+    <!-- HTML -->
+    <template v-if="isHtml && body">
+      <div
+        v-if="htmlMode === 'preview'"
+        class="http-body-view__html-preview"
+      >
+        <iframe
+          :srcdoc="body"
+          sandbox=""
+          class="http-body-view__iframe"
+        />
+        <button
+          class="http-body-view__open-tab"
+          @click="openHtmlPreview"
+        >
+          Open in new tab
+        </button>
+      </div>
+
+      <CodeSnippet
+        v-if="htmlMode === 'source'"
+        language="html"
+        :code="body"
+      />
+    </template>
+
+    <!-- JSON Tree mode -->
+    <JsonTreeView
+      v-else-if="isJson && viewMode === 'tree' && parsed"
+      :value="parsed"
+    />
+
+    <!-- JSON Pretty mode -->
+    <CodeSnippet
+      v-else-if="isJson && viewMode === 'pretty'"
+      language="json"
+      :code="prettyJson"
+    />
+
+    <!-- JSON Raw mode or non-JSON fallback -->
+    <CodeSnippet
+      v-else
+      :language="language"
+      :code="body"
+    />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.http-body-view__header {
+  @apply flex items-center justify-between gap-2 mb-3;
+}
+
+.http-body-view__meta {
+  @apply flex items-center gap-2;
+}
+
+.http-body-view__tag {
+  @apply inline-flex items-center px-1.5 py-0.5 rounded;
+  @apply text-2xs font-mono;
+  @apply bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400;
+}
+
+.http-body-view__html-preview {
+  @apply border border-gray-200 dark:border-gray-700 rounded overflow-hidden relative;
+}
+
+.http-body-view__iframe {
+  @apply w-full bg-white;
+  max-height: 400px;
+  border: none;
+}
+
+.http-body-view__open-tab {
+  @apply absolute top-2 right-2 px-2 py-1 rounded;
+  @apply text-2xs font-medium cursor-pointer;
+  @apply bg-gray-100/90 dark:bg-gray-800/90 text-gray-600 dark:text-gray-300;
+  @apply hover:bg-gray-200 dark:hover:bg-gray-700;
+  @apply transition-colors duration-150;
+}
+</style>

--- a/src/entities/http-dump/ui/http-body-view/index.ts
+++ b/src/entities/http-dump/ui/http-body-view/index.ts
@@ -1,0 +1,1 @@
+export { default as HttpBodyView } from './http-body-view.vue'

--- a/src/entities/http-dump/ui/http-dump-header/http-dump-header.stories.ts
+++ b/src/entities/http-dump/ui/http-dump-header/http-dump-header.stories.ts
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { useHttpDump } from '../../lib'
+import {
+  httpDumpMock,
+  httpDumpProxyJsonMock,
+  httpDumpProxy4xxMock,
+  httpDumpProxyErrorMock,
+} from '../../mocks'
+import HttpDumpHeader from './http-dump-header.vue'
+
+const { normalizeHttpDumpEvent } = useHttpDump()
+
+export default {
+  title: 'Entities/HttpDump/HttpDumpHeader',
+  component: HttpDumpHeader,
+} as Meta<typeof HttpDumpHeader>
+
+export const RegularDump: StoryObj<typeof HttpDumpHeader> = {
+  args: {
+    event: normalizeHttpDumpEvent(httpDumpMock),
+  },
+}
+
+export const ProxySuccess: StoryObj<typeof HttpDumpHeader> = {
+  args: {
+    event: normalizeHttpDumpEvent(httpDumpProxyJsonMock),
+  },
+}
+
+export const Proxy4xx: StoryObj<typeof HttpDumpHeader> = {
+  args: {
+    event: normalizeHttpDumpEvent(httpDumpProxy4xxMock),
+  },
+}
+
+export const ProxyConnectionError: StoryObj<typeof HttpDumpHeader> = {
+  args: {
+    event: normalizeHttpDumpEvent(httpDumpProxyErrorMock),
+  },
+}

--- a/src/entities/http-dump/ui/http-dump-header/http-dump-header.vue
+++ b/src/entities/http-dump/ui/http-dump-header/http-dump-header.vue
@@ -1,0 +1,199 @@
+<script lang="ts" setup>
+import { ref, toRef } from 'vue'
+import { copyTextToClipboard } from '@/shared/lib/clipboard'
+import type { NormalizedEvent } from '@/shared/types'
+import { IconSvg } from '@/shared/ui'
+import { useHttpDumpEvent } from '../../lib'
+import type { HttpDump } from '../../types'
+
+type Props = {
+  event: NormalizedEvent<HttpDump>
+}
+
+const props = defineProps<Props>()
+
+const {
+  isProxy,
+  method,
+  uri,
+  contentType,
+  statusCode,
+  durationMs,
+  proxyError,
+  methodColor,
+  statusColor,
+  curlCommand
+} = useHttpDumpEvent(toRef(props, 'event'))
+
+const STATUS_TEXT: Record<number, string> = {
+  200: 'OK',
+  201: 'Created',
+  204: 'No Content',
+  301: 'Moved Permanently',
+  302: 'Found',
+  304: 'Not Modified',
+  400: 'Bad Request',
+  401: 'Unauthorized',
+  403: 'Forbidden',
+  404: 'Not Found',
+  409: 'Conflict',
+  422: 'Unprocessable Entity',
+  429: 'Too Many Requests',
+  500: 'Internal Server Error',
+  502: 'Bad Gateway',
+  503: 'Service Unavailable',
+  504: 'Gateway Timeout'
+}
+
+const statusText = (code: number) => STATUS_TEXT[code] || ''
+
+const isCurlCopied = ref(false)
+const isUrlCopied = ref(false)
+
+const copyCurl = () => {
+  isCurlCopied.value = true
+  copyTextToClipboard(curlCommand.value).catch(console.error)
+  setTimeout(() => {
+    isCurlCopied.value = false
+  }, 1500)
+}
+
+const copyUrl = () => {
+  isUrlCopied.value = true
+  copyTextToClipboard(uri.value).catch(console.error)
+  setTimeout(() => {
+    isUrlCopied.value = false
+  }, 1500)
+}
+</script>
+
+<template>
+  <div class="http-dump-header">
+    <div class="http-dump-header__main">
+      <div class="http-dump-header__row">
+        <span
+          class="http-dump-header__badge"
+          :class="methodColor"
+        >{{ method }}</span>
+
+        <template v-if="statusCode">
+          <span
+            class="http-dump-header__badge"
+            :class="statusColor"
+          >{{ statusCode }} {{ statusText(statusCode) }}</span>
+        </template>
+
+        <span class="http-dump-header__uri">{{ uri }}</span>
+      </div>
+
+      <div class="http-dump-header__actions">
+        <button
+          class="http-dump-header__action"
+          :title="isCurlCopied ? 'Copied!' : 'Copy cURL'"
+          @click="copyCurl"
+        >
+          <IconSvg
+            name="copy"
+            class="w-3.5 h-3.5"
+          />
+          <span>{{ isCurlCopied ? 'Copied' : 'cURL' }}</span>
+        </button>
+
+        <button
+          class="http-dump-header__action"
+          :title="isUrlCopied ? 'Copied!' : 'Copy URL'"
+          @click="copyUrl"
+        >
+          <IconSvg
+            name="copy"
+            class="w-3.5 h-3.5"
+          />
+          <span>{{ isUrlCopied ? 'Copied' : 'URL' }}</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="http-dump-header__meta">
+      <span
+        v-if="isProxy"
+        class="http-dump-header__tag http-dump-header__tag--proxy"
+      >proxy</span>
+      <span
+        v-if="durationMs != null"
+        class="http-dump-header__tag"
+      >{{ durationMs }}ms</span>
+      <span
+        v-if="contentType"
+        class="http-dump-header__tag"
+      >{{ contentType }}</span>
+    </div>
+
+    <div
+      v-if="proxyError"
+      class="http-dump-header__error"
+    >
+      {{ proxyError }}
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.http-dump-header {
+  @apply flex flex-col gap-2;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  @apply bg-white dark:bg-gray-900;
+  @apply pb-3 -mb-1;
+}
+
+.http-dump-header__main {
+  @apply flex items-start justify-between gap-3;
+}
+
+.http-dump-header__row {
+  @apply flex items-baseline gap-2 font-mono text-sm flex-1 min-w-0;
+}
+
+.http-dump-header__badge {
+  @apply font-bold text-xs px-2 py-0.5 rounded uppercase tracking-wide flex-shrink-0;
+}
+
+.http-dump-header__uri {
+  @apply text-gray-700 dark:text-gray-200 break-all;
+}
+
+.http-dump-header__actions {
+  @apply flex items-center gap-1 flex-shrink-0;
+}
+
+.http-dump-header__action {
+  @apply flex items-center gap-1 px-2 py-1 rounded;
+  @apply text-2xs font-medium cursor-pointer;
+  @apply text-gray-500 dark:text-gray-400;
+  @apply bg-gray-100 dark:bg-gray-800;
+  @apply hover:text-gray-700 dark:hover:text-gray-200;
+  @apply transition-colors duration-150;
+}
+
+.http-dump-header__meta {
+  @apply flex items-center gap-2;
+}
+
+.http-dump-header__tag {
+  @apply inline-flex items-center px-1.5 py-0.5 rounded;
+  @apply text-2xs font-mono;
+  @apply bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400;
+}
+
+.http-dump-header__tag--proxy {
+  @apply bg-violet-100 dark:bg-violet-500/10 text-violet-600 dark:text-violet-400;
+}
+
+.http-dump-header__error {
+  @apply text-xs font-mono text-red-700 dark:text-red-300;
+  @apply bg-red-50 dark:bg-red-900/20;
+  @apply border-l-4 border-red-500;
+  @apply px-4 py-2 rounded-r;
+}
+</style>

--- a/src/entities/http-dump/ui/http-dump-header/index.ts
+++ b/src/entities/http-dump/ui/http-dump-header/index.ts
@@ -1,0 +1,1 @@
+export { default as HttpDumpHeader } from './http-dump-header.vue'

--- a/src/entities/http-dump/ui/http-dump-page/http-dump-page.stories.ts
+++ b/src/entities/http-dump/ui/http-dump-page/http-dump-page.stories.ts
@@ -1,6 +1,15 @@
 import type { Meta, StoryObj } from "@storybook/vue3-vite";
 import { useHttpDump } from '../../lib';
-import { httpDumpMock, httpDumpPdfMock } from '../../mocks';
+import {
+  httpDumpMock,
+  httpDumpPdfMock,
+  httpDumpProxyJsonMock,
+  httpDumpProxyHtmlMock,
+  httpDumpProxyErrorMock,
+  httpDumpProxyXmlMock,
+  httpDumpProxyBinaryMock,
+  httpDumpProxy4xxMock,
+} from '../../mocks';
 import HttpDumpPage from "./http-dump-page.vue";
 
 const { normalizeHttpDumpEvent } = useHttpDump();
@@ -22,5 +31,41 @@ export const Default: StoryObj<typeof HttpDumpPage> = {
 export const WithPdf: StoryObj<typeof HttpDumpPage> = {
   args: {
     event: normalizeHttpDumpEvent(httpDumpPdfMock),
+  }
+}
+
+export const ProxyJsonResponse: StoryObj<typeof HttpDumpPage> = {
+  args: {
+    event: normalizeHttpDumpEvent(httpDumpProxyJsonMock),
+  }
+}
+
+export const ProxyHtmlResponse: StoryObj<typeof HttpDumpPage> = {
+  args: {
+    event: normalizeHttpDumpEvent(httpDumpProxyHtmlMock),
+  }
+}
+
+export const ProxyXmlResponse: StoryObj<typeof HttpDumpPage> = {
+  args: {
+    event: normalizeHttpDumpEvent(httpDumpProxyXmlMock),
+  }
+}
+
+export const ProxyBinaryResponse: StoryObj<typeof HttpDumpPage> = {
+  args: {
+    event: normalizeHttpDumpEvent(httpDumpProxyBinaryMock),
+  }
+}
+
+export const Proxy4xxError: StoryObj<typeof HttpDumpPage> = {
+  args: {
+    event: normalizeHttpDumpEvent(httpDumpProxy4xxMock),
+  }
+}
+
+export const ProxyConnectionError: StoryObj<typeof HttpDumpPage> = {
+  args: {
+    event: normalizeHttpDumpEvent(httpDumpProxyErrorMock),
   }
 }

--- a/src/entities/http-dump/ui/http-dump-page/http-dump-page.stories.ts
+++ b/src/entities/http-dump/ui/http-dump-page/http-dump-page.stories.ts
@@ -19,7 +19,10 @@ export default {
   component: HttpDumpPage,
   parameters: {
     layout: 'fullscreen',
-  }
+  },
+  args: {
+    useUrlFragment: false,
+  },
 } as Meta<typeof HttpDumpPage>;
 
 export const Default: StoryObj<typeof HttpDumpPage> = {

--- a/src/entities/http-dump/ui/http-dump-page/http-dump-page.vue
+++ b/src/entities/http-dump/ui/http-dump-page/http-dump-page.vue
@@ -23,7 +23,15 @@ const { calcDownloadLink } = useAttachments('http-dump')
 const calcDownloadUrl = (attachmentId: Attachment['uuid']) =>
   calcDownloadLink(props.event.id, attachmentId)
 
-const uri = computed(() => decodeURI(props.event.payload?.request?.uri))
+const isProxy = computed(() => !!props.event.payload.proxy)
+
+const uri = computed(() => {
+  const rawUri = decodeURI(props.event.payload?.request?.uri)
+  if (isProxy.value) {
+    return `${props.event.payload.host}${rawUri}`
+  }
+  return rawUri
+})
 
 const hasPostData = computed(
   () =>
@@ -79,11 +87,87 @@ const contentType = computed(() => {
   return val?.split(';')[0]?.trim() || null
 })
 
+// Response
+const response = computed(() => props.event.payload.response)
+const hasResponse = computed(() => !!response.value)
+const statusCode = computed(() => response.value?.status_code)
+const durationMs = computed(() => props.event.payload.duration_ms)
+const proxyError = computed(() => props.event.payload.error)
+
+const statusColor = computed(() => {
+  const code = statusCode.value
+  if (!code) return ''
+  if (code >= 500) return 'text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-500/10'
+  if (code >= 400) return 'text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-500/10'
+  if (code >= 300) return 'text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-500/10'
+  return 'text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-500/10'
+})
+
+const hasResponseHeaders = computed(() => Object.keys(response.value?.headers || {}).length > 0)
+
+const responseContentType = computed(() => {
+  if (!response.value?.headers) return null
+  const ct = response.value.headers['content-type'] || response.value.headers['Content-Type']
+  if (!ct) return null
+  const val = Array.isArray(ct) ? ct[0] : ct
+  return val?.split(';')[0]?.trim() || null
+})
+
+const responseBodyLanguage = computed(() => {
+  const ct = responseContentType.value
+  if (!ct) return 'plaintext'
+  if (ct.includes('json')) return 'json'
+  if (ct.includes('xml') || ct.includes('svg')) return 'xml'
+  if (ct.includes('html')) return 'html'
+  if (ct.includes('css')) return 'css'
+  if (ct.includes('javascript')) return 'javascript'
+  return 'plaintext'
+})
+
+const responseBody = computed(() => {
+  const body = response.value?.body
+  if (!body) return null
+  // Try to pretty-print JSON
+  if (responseBodyLanguage.value === 'json') {
+    try {
+      return JSON.stringify(JSON.parse(body), null, 2)
+    } catch {
+      return body
+    }
+  }
+  return body
+})
+
+const isBinaryResponse = computed(() => {
+  const ct = responseContentType.value
+  if (!ct) return false
+  return (
+    ct.startsWith('image/') ||
+    ct.startsWith('audio/') ||
+    ct.startsWith('video/') ||
+    ct.includes('octet-stream') ||
+    ct.includes('zip') ||
+    ct.includes('gzip') ||
+    ct.includes('tar') ||
+    ct.includes('pdf')
+  )
+})
+
+const responseBodySize = computed(() => {
+  const len = response.value?.body?.length || 0
+  if (!len) return null
+  if (len < 1024) return `${len} B`
+  if (len < 1024 * 1024) return `${(len / 1024).toFixed(1)} KB`
+  return `${(len / (1024 * 1024)).toFixed(1)} MB`
+})
+
 const curlCommand = computed(() => {
   const req = props.event.payload.request
   let curl = `curl -X ${req.method}`
 
-  if (host.value) {
+  if (isProxy.value) {
+    curl += ` '${props.event.payload.host}${req.uri}'`
+  } else if (host.value) {
     curl += ` '${host.value}${req.uri}'`
   } else {
     curl += ` '${req.uri}'`
@@ -131,13 +215,28 @@ const rawHttp = computed(() => {
               class="http-header__method"
               :class="methodColor"
             >{{ method }}</span>
+            <span
+              v-if="statusCode"
+              class="http-header__method"
+              :class="statusColor"
+            >{{
+              statusCode
+            }}</span>
             <span class="http-header__uri">{{ uri }}</span>
           </div>
         </div>
 
         <div class="http-header__meta">
           <span
-            v-if="host"
+            v-if="isProxy"
+            class="http-header__tag http-header__tag--proxy"
+          >proxy</span>
+          <span
+            v-if="durationMs != null"
+            class="http-header__tag"
+          >{{ durationMs }}ms</span>
+          <span
+            v-if="!isProxy && host"
             class="http-header__tag"
           >{{ host }}</span>
           <span
@@ -145,10 +244,79 @@ const rawHttp = computed(() => {
             class="http-header__tag"
           >{{ contentType }}</span>
         </div>
+
+        <div
+          v-if="proxyError"
+          class="http-header__error"
+        >
+          {{ proxyError }}
+        </div>
       </div>
     </template>
 
-    <!-- 1. Structured request data -->
+    <!-- Response section (proxy events) -->
+    <template v-if="hasResponse">
+      <EventDetailSection
+        v-if="hasResponseHeaders"
+        title="Response Headers"
+      >
+        <TableBase>
+          <TableBaseRow
+            v-for="(value, key) in response!.headers"
+            :key="key"
+            :title="String(key)"
+          >
+            {{ Array.isArray(value) ? value[0] : value }}
+          </TableBaseRow>
+        </TableBase>
+      </EventDetailSection>
+
+      <EventDetailSection
+        v-if="responseBody && !isBinaryResponse"
+        title="Response Body"
+      >
+        <div class="http-response-meta">
+          <span
+            v-if="responseContentType"
+            class="http-header__tag"
+          >{{ responseContentType }}</span>
+          <span
+            v-if="responseBodySize"
+            class="http-header__tag"
+          >{{ responseBodySize }}</span>
+        </div>
+
+        <!-- HTML preview -->
+        <div
+          v-if="responseBodyLanguage === 'html'"
+          class="http-response-preview"
+        >
+          <iframe
+            :srcdoc="response!.body"
+            sandbox=""
+            class="http-response-preview__iframe"
+          />
+        </div>
+
+        <CodeSnippet
+          :language="responseBodyLanguage"
+          :code="responseBody"
+        />
+      </EventDetailSection>
+
+      <EventDetailSection
+        v-if="isBinaryResponse"
+        title="Response Body"
+      >
+        <div class="http-response-binary">
+          <span class="http-header__tag">{{ responseContentType }}</span>
+          <span class="http-header__tag">{{ responseBodySize }}</span>
+          <span class="text-xs text-gray-500 dark:text-gray-400">Binary content — not displayed</span>
+        </div>
+      </EventDetailSection>
+    </template>
+
+    <!-- Request sections -->
     <EventDetailSection
       v-if="hasQuery"
       title="Query Parameters"
@@ -181,7 +349,7 @@ const rawHttp = computed(() => {
 
     <EventDetailSection
       v-if="hasHeaders"
-      title="Headers"
+      title="Request Headers"
     >
       <TableBase>
         <TableBaseRow
@@ -225,7 +393,7 @@ const rawHttp = computed(() => {
       </div>
     </EventDetailSection>
 
-    <!-- 2. Raw formats -->
+    <!-- Raw formats -->
     <div class="http-raw">
       <EventDetailSection title="cURL">
         <CodeSnippet
@@ -273,6 +441,34 @@ const rawHttp = computed(() => {
   @apply inline-flex items-center px-1.5 py-0.5 rounded;
   @apply text-2xs font-mono;
   @apply bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400;
+}
+
+.http-header__tag--proxy {
+  @apply bg-violet-100 dark:bg-violet-500/10 text-violet-600 dark:text-violet-400;
+}
+
+.http-header__error {
+  @apply text-xs font-mono text-red-600 dark:text-red-400;
+  @apply bg-red-50 dark:bg-red-500/10 px-2 py-1 rounded;
+}
+
+/* Response preview */
+.http-response-meta {
+  @apply flex items-center gap-2 mb-3;
+}
+
+.http-response-preview {
+  @apply mb-3 border border-gray-200 dark:border-gray-700 rounded overflow-hidden;
+}
+
+.http-response-preview__iframe {
+  @apply w-full bg-white;
+  height: 300px;
+  border: none;
+}
+
+.http-response-binary {
+  @apply flex items-center gap-3 py-3;
 }
 
 /* Raw formats section — visually separated */

--- a/src/entities/http-dump/ui/http-dump-page/http-dump-page.vue
+++ b/src/entities/http-dump/ui/http-dump-page/http-dump-page.vue
@@ -1,479 +1,90 @@
 <script lang="ts" setup>
-import { computed } from 'vue'
-import { useAttachments } from '@/shared/lib/io'
-import type { NormalizedEvent, Attachment } from '@/shared/types'
-import {
-  TableBase,
-  TableBaseRow,
-  FileAttachment,
-  CodeSnippet,
-  EventDetailLayout,
-  EventDetailSection
-} from '@/shared/ui'
+import { toRef } from 'vue'
+import type { NormalizedEvent } from '@/shared/types'
+import { CodeSnippet, EventDetailLayout, EventDetailSection, PageTabs, PageTab } from '@/shared/ui'
+import { useHttpDumpEvent } from '../../lib'
 import type { HttpDump } from '../../types'
+import { HttpDumpHeader } from '../http-dump-header'
+import { HttpRequestPanel } from '../http-request-panel'
+import { HttpResponsePanel } from '../http-response-panel'
 
 type Props = {
   event: NormalizedEvent<HttpDump>
+  useUrlFragment?: boolean
 }
 
-const props = defineProps<Props>()
-
-const { calcDownloadLink } = useAttachments('http-dump')
-
-const calcDownloadUrl = (attachmentId: Attachment['uuid']) =>
-  calcDownloadLink(props.event.id, attachmentId)
-
-const isProxy = computed(() => !!props.event.payload.proxy)
-
-const uri = computed(() => {
-  const rawUri = decodeURI(props.event.payload?.request?.uri)
-  if (isProxy.value) {
-    return `${props.event.payload.host}${rawUri}`
-  }
-  return rawUri
+const props = withDefaults(defineProps<Props>(), {
+  useUrlFragment: true
 })
 
-const hasPostData = computed(
-  () =>
-    props.event.payload?.request?.post && Object.keys(props.event.payload?.request?.post).length > 0
-)
-
-const hasQuery = computed(
-  () =>
-    props.event.payload?.request?.query &&
-    Object.keys(props.event.payload?.request?.query).length > 0
-)
-
-const hasHeaders = computed(
-  () => Object.keys(props.event.payload?.request?.headers || {}).length > 0
-)
-
-const hasCookies = computed(
-  () =>
-    props.event.payload?.request?.cookies &&
-    Object.keys(props.event.payload?.request?.cookies).length > 0
-)
-
-const hasAttachments = computed(
-  () =>
-    props.event.payload?.request?.files &&
-    Object.keys(props.event.payload?.request?.files).length > 0
-)
-
-const method = computed(() => props.event.payload.request.method)
-
-const methodColor = computed(() => {
-  const m = method.value?.toUpperCase()
-  if (m === 'GET') return 'text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-500/10'
-  if (m === 'POST') return 'text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-500/10'
-  if (m === 'PUT' || m === 'PATCH')
-    return 'text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-500/10'
-  if (m === 'DELETE') return 'text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-500/10'
-  return 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-500/10'
-})
-
-const host = computed(() => {
-  const h = props.event.payload.request.headers?.host
-  if (!h) return null
-  return Array.isArray(h) ? h[0] : h
-})
-
-const contentType = computed(() => {
-  const ct =
-    props.event.payload.request.headers?.['content-type'] ||
-    props.event.payload.request.headers?.['Content-Type']
-  if (!ct) return null
-  const val = Array.isArray(ct) ? ct[0] : ct
-  return val?.split(';')[0]?.trim() || null
-})
-
-// Response
-const response = computed(() => props.event.payload.response)
-const hasResponse = computed(() => !!response.value)
-const statusCode = computed(() => response.value?.status_code)
-const durationMs = computed(() => props.event.payload.duration_ms)
-const proxyError = computed(() => props.event.payload.error)
-
-const statusColor = computed(() => {
-  const code = statusCode.value
-  if (!code) return ''
-  if (code >= 500) return 'text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-500/10'
-  if (code >= 400) return 'text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-500/10'
-  if (code >= 300) return 'text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-500/10'
-  return 'text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-500/10'
-})
-
-const hasResponseHeaders = computed(() => Object.keys(response.value?.headers || {}).length > 0)
-
-const responseContentType = computed(() => {
-  if (!response.value?.headers) return null
-  const ct = response.value.headers['content-type'] || response.value.headers['Content-Type']
-  if (!ct) return null
-  const val = Array.isArray(ct) ? ct[0] : ct
-  return val?.split(';')[0]?.trim() || null
-})
-
-const responseBodyLanguage = computed(() => {
-  const ct = responseContentType.value
-  if (!ct) return 'plaintext'
-  if (ct.includes('json')) return 'json'
-  if (ct.includes('xml') || ct.includes('svg')) return 'xml'
-  if (ct.includes('html')) return 'html'
-  if (ct.includes('css')) return 'css'
-  if (ct.includes('javascript')) return 'javascript'
-  return 'plaintext'
-})
-
-const responseBody = computed(() => {
-  const body = response.value?.body
-  if (!body) return null
-  // Try to pretty-print JSON
-  if (responseBodyLanguage.value === 'json') {
-    try {
-      return JSON.stringify(JSON.parse(body), null, 2)
-    } catch {
-      return body
-    }
-  }
-  return body
-})
-
-const isBinaryResponse = computed(() => {
-  const ct = responseContentType.value
-  if (!ct) return false
-  return (
-    ct.startsWith('image/') ||
-    ct.startsWith('audio/') ||
-    ct.startsWith('video/') ||
-    ct.includes('octet-stream') ||
-    ct.includes('zip') ||
-    ct.includes('gzip') ||
-    ct.includes('tar') ||
-    ct.includes('pdf')
-  )
-})
-
-const responseBodySize = computed(() => {
-  const len = response.value?.body?.length || 0
-  if (!len) return null
-  if (len < 1024) return `${len} B`
-  if (len < 1024 * 1024) return `${(len / 1024).toFixed(1)} KB`
-  return `${(len / (1024 * 1024)).toFixed(1)} MB`
-})
-
-const curlCommand = computed(() => {
-  const req = props.event.payload.request
-  let curl = `curl -X ${req.method}`
-
-  if (isProxy.value) {
-    curl += ` '${props.event.payload.host}${req.uri}'`
-  } else if (host.value) {
-    curl += ` '${host.value}${req.uri}'`
-  } else {
-    curl += ` '${req.uri}'`
-  }
-
-  const headers = req.headers || {}
-  for (const [key, val] of Object.entries(headers)) {
-    if (key.toLowerCase() === 'host') continue
-    const v = Array.isArray(val) ? val[0] : val
-    curl += ` \\\n  -H '${key}: ${v}'`
-  }
-
-  if (req.body) {
-    curl += ` \\\n  -d '${req.body.replace(/'/g, "'\\''")}'`
-  }
-
-  return curl
-})
-
-const rawHttp = computed(() => {
-  const req = props.event.payload.request
-  let raw = `${req.method} ${req.uri} HTTP/1.1\n`
-
-  const headers = req.headers || {}
-  for (const [key, val] of Object.entries(headers)) {
-    const v = Array.isArray(val) ? val[0] : val
-    raw += `${key}: ${v}\n`
-  }
-
-  if (req.body) {
-    raw += `\n${req.body}`
-  }
-
-  return raw
-})
+const { hasResponse, curlCommand, rawHttp } = useHttpDumpEvent(toRef(props, 'event'))
 </script>
 
 <template>
   <EventDetailLayout :date="event.date">
     <template #header>
-      <div class="http-header">
-        <div class="http-header__top">
-          <div class="http-header__row">
-            <span
-              class="http-header__method"
-              :class="methodColor"
-            >{{ method }}</span>
-            <span
-              v-if="statusCode"
-              class="http-header__method"
-              :class="statusColor"
-            >{{
-              statusCode
-            }}</span>
-            <span class="http-header__uri">{{ uri }}</span>
+      <HttpDumpHeader :event="event" />
+    </template>
+
+    <div class="http-dump-tabs">
+      <PageTabs :use-url-fragment="useUrlFragment">
+        <!-- Proxy: RESPONSE tab first (default) -->
+        <PageTab
+          v-if="hasResponse"
+          name="Response"
+        >
+          <div class="http-dump-tabs__panel">
+            <HttpResponsePanel :event="event" />
           </div>
-        </div>
+        </PageTab>
 
-        <div class="http-header__meta">
-          <span
-            v-if="isProxy"
-            class="http-header__tag http-header__tag--proxy"
-          >proxy</span>
-          <span
-            v-if="durationMs != null"
-            class="http-header__tag"
-          >{{ durationMs }}ms</span>
-          <span
-            v-if="!isProxy && host"
-            class="http-header__tag"
-          >{{ host }}</span>
-          <span
-            v-if="contentType"
-            class="http-header__tag"
-          >{{ contentType }}</span>
-        </div>
+        <PageTab name="Request">
+          <div class="http-dump-tabs__panel">
+            <HttpRequestPanel :event="event" />
+          </div>
+        </PageTab>
 
-        <div
-          v-if="proxyError"
-          class="http-header__error"
-        >
-          {{ proxyError }}
-        </div>
-      </div>
-    </template>
+        <PageTab name="Raw">
+          <div class="http-dump-tabs__panel">
+            <EventDetailSection title="cURL">
+              <CodeSnippet
+                language="bash"
+                :code="curlCommand"
+              />
+            </EventDetailSection>
 
-    <!-- Response section (proxy events) -->
-    <template v-if="hasResponse">
-      <EventDetailSection
-        v-if="hasResponseHeaders"
-        title="Response Headers"
-      >
-        <TableBase>
-          <TableBaseRow
-            v-for="(value, key) in response!.headers"
-            :key="key"
-            :title="String(key)"
-          >
-            {{ Array.isArray(value) ? value[0] : value }}
-          </TableBaseRow>
-        </TableBase>
-      </EventDetailSection>
-
-      <EventDetailSection
-        v-if="responseBody && !isBinaryResponse"
-        title="Response Body"
-      >
-        <div class="http-response-meta">
-          <span
-            v-if="responseContentType"
-            class="http-header__tag"
-          >{{ responseContentType }}</span>
-          <span
-            v-if="responseBodySize"
-            class="http-header__tag"
-          >{{ responseBodySize }}</span>
-        </div>
-
-        <!-- HTML preview -->
-        <div
-          v-if="responseBodyLanguage === 'html'"
-          class="http-response-preview"
-        >
-          <iframe
-            :srcdoc="response!.body"
-            sandbox=""
-            class="http-response-preview__iframe"
-          />
-        </div>
-
-        <CodeSnippet
-          :language="responseBodyLanguage"
-          :code="responseBody"
-        />
-      </EventDetailSection>
-
-      <EventDetailSection
-        v-if="isBinaryResponse"
-        title="Response Body"
-      >
-        <div class="http-response-binary">
-          <span class="http-header__tag">{{ responseContentType }}</span>
-          <span class="http-header__tag">{{ responseBodySize }}</span>
-          <span class="text-xs text-gray-500 dark:text-gray-400">Binary content — not displayed</span>
-        </div>
-      </EventDetailSection>
-    </template>
-
-    <!-- Request sections -->
-    <EventDetailSection
-      v-if="hasQuery"
-      title="Query Parameters"
-    >
-      <TableBase>
-        <TableBaseRow
-          v-for="(value, key) in event.payload.request.query"
-          :key="key"
-          :title="String(key)"
-        >
-          {{ value }}
-        </TableBaseRow>
-      </TableBase>
-    </EventDetailSection>
-
-    <EventDetailSection
-      v-if="hasPostData"
-      title="POST Data"
-    >
-      <TableBase>
-        <TableBaseRow
-          v-for="(value, key) in event.payload.request.post"
-          :key="key"
-          :title="String(key)"
-        >
-          {{ value }}
-        </TableBaseRow>
-      </TableBase>
-    </EventDetailSection>
-
-    <EventDetailSection
-      v-if="hasHeaders"
-      title="Request Headers"
-    >
-      <TableBase>
-        <TableBaseRow
-          v-for="(value, key) in event.payload.request.headers"
-          :key="key"
-          :title="String(key)"
-        >
-          {{ value[0] || value }}
-        </TableBaseRow>
-      </TableBase>
-    </EventDetailSection>
-
-    <EventDetailSection
-      v-if="hasCookies"
-      title="Cookies"
-    >
-      <TableBase>
-        <TableBaseRow
-          v-for="(value, key) in event.payload.request.cookies"
-          :key="key"
-          :title="String(key)"
-        >
-          {{ value }}
-        </TableBaseRow>
-      </TableBase>
-    </EventDetailSection>
-
-    <EventDetailSection
-      v-if="hasAttachments"
-      title="Attachments"
-      :count="event.payload.request.files?.length || 0"
-    >
-      <div class="flex gap-x-3">
-        <FileAttachment
-          v-for="file in event.payload.request.files"
-          :key="file.uuid"
-          :event-id="event.id"
-          :attachment="file"
-          :download-url="calcDownloadUrl(file.uuid)"
-        />
-      </div>
-    </EventDetailSection>
-
-    <!-- Raw formats -->
-    <div class="http-raw">
-      <EventDetailSection title="cURL">
-        <CodeSnippet
-          language="bash"
-          :code="curlCommand"
-        />
-      </EventDetailSection>
-
-      <EventDetailSection title="Raw HTTP">
-        <CodeSnippet
-          language="plaintext"
-          :code="rawHttp"
-        />
-      </EventDetailSection>
+            <EventDetailSection title="Raw HTTP">
+              <CodeSnippet
+                language="plaintext"
+                :code="rawHttp"
+              />
+            </EventDetailSection>
+          </div>
+        </PageTab>
+      </PageTabs>
     </div>
   </EventDetailLayout>
 </template>
 
 <style lang="scss" scoped>
-.http-header {
-  @apply flex flex-col gap-2;
+/* Pull tabs to the edges — counteract the parent body padding */
+.http-dump-tabs {
+  @apply -mx-5 md:-mx-6 lg:-mx-8 -mb-5 -mt-1;
+  @apply flex-grow flex flex-col;
+
+  /* Override tabs h-full so background extends with content */
+  :deep(.tabs-component) {
+    @apply h-auto flex-grow;
+  }
+
+  /* Add left padding to tab bar to align with content */
+  :deep(.tabs-component-tabs) {
+    @apply px-5 md:px-6 lg:px-8;
+  }
 }
 
-.http-header__top {
-  @apply flex items-center justify-between gap-3;
-}
-
-.http-header__row {
-  @apply flex items-baseline gap-3 font-mono;
-}
-
-.http-header__method {
-  @apply font-bold text-sm px-2 py-0.5 rounded uppercase tracking-wide flex-shrink-0;
-}
-
-.http-header__uri {
-  @apply text-sm text-gray-700 dark:text-gray-200 break-all;
-}
-
-.http-header__meta {
-  @apply flex items-center gap-2;
-}
-
-.http-header__tag {
-  @apply inline-flex items-center px-1.5 py-0.5 rounded;
-  @apply text-2xs font-mono;
-  @apply bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400;
-}
-
-.http-header__tag--proxy {
-  @apply bg-violet-100 dark:bg-violet-500/10 text-violet-600 dark:text-violet-400;
-}
-
-.http-header__error {
-  @apply text-xs font-mono text-red-600 dark:text-red-400;
-  @apply bg-red-50 dark:bg-red-500/10 px-2 py-1 rounded;
-}
-
-/* Response preview */
-.http-response-meta {
-  @apply flex items-center gap-2 mb-3;
-}
-
-.http-response-preview {
-  @apply mb-3 border border-gray-200 dark:border-gray-700 rounded overflow-hidden;
-}
-
-.http-response-preview__iframe {
-  @apply w-full bg-white;
-  height: 300px;
-  border: none;
-}
-
-.http-response-binary {
-  @apply flex items-center gap-3 py-3;
-}
-
-/* Raw formats section — visually separated */
-.http-raw {
-  @apply flex flex-col gap-6 pt-4 mt-2;
-  @apply border-t border-gray-200 dark:border-gray-700;
+/* Restore padding inside each tab panel */
+.http-dump-tabs__panel {
+  @apply py-5 px-5 md:px-6 lg:px-8 flex flex-col gap-6;
 }
 </style>

--- a/src/entities/http-dump/ui/http-request-panel/http-request-panel.stories.ts
+++ b/src/entities/http-dump/ui/http-request-panel/http-request-panel.stories.ts
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { useHttpDump } from '../../lib'
+import {
+  httpDumpMock,
+  httpDumpProxyJsonMock,
+  httpDumpProxy4xxMock,
+} from '../../mocks'
+import HttpRequestPanel from './http-request-panel.vue'
+
+const { normalizeHttpDumpEvent } = useHttpDump()
+
+export default {
+  title: 'Entities/HttpDump/HttpRequestPanel',
+  component: HttpRequestPanel,
+} as Meta<typeof HttpRequestPanel>
+
+export const WithQueryAndHeaders: StoryObj<typeof HttpRequestPanel> = {
+  args: {
+    event: normalizeHttpDumpEvent(httpDumpMock),
+  },
+}
+
+export const ProxyPostWithJsonBody: StoryObj<typeof HttpRequestPanel> = {
+  args: {
+    event: normalizeHttpDumpEvent(httpDumpProxyJsonMock),
+  },
+}
+
+export const ProxyFormBody: StoryObj<typeof HttpRequestPanel> = {
+  args: {
+    event: normalizeHttpDumpEvent(httpDumpProxy4xxMock),
+  },
+}

--- a/src/entities/http-dump/ui/http-request-panel/http-request-panel.vue
+++ b/src/entities/http-dump/ui/http-request-panel/http-request-panel.vue
@@ -1,0 +1,210 @@
+<script lang="ts" setup>
+import { computed, ref, toRef } from 'vue'
+import { useAttachments } from '@/shared/lib/io'
+import type { NormalizedEvent, Attachment } from '@/shared/types'
+import { TableBase, TableBaseRow, FileAttachment, EventDetailSection } from '@/shared/ui'
+import { useHttpDumpEvent } from '../../lib'
+import type { HttpDump } from '../../types'
+import { HttpBodyView } from '../http-body-view'
+import HttpBodyViewToggle from '../http-body-view/http-body-view-toggle.vue'
+
+type Props = {
+  event: NormalizedEvent<HttpDump>
+}
+
+const props = defineProps<Props>()
+
+const { calcDownloadLink } = useAttachments('http-dump')
+const calcDownloadUrl = (attachmentId: Attachment['uuid']) =>
+  calcDownloadLink(props.event.id, attachmentId)
+
+const bodyViewRef = ref<InstanceType<typeof HttpBodyView> | null>(null)
+
+const {
+  contentType,
+  hasBody,
+  bodySize,
+  hasQuery,
+  hasPostData,
+  hasHeaders,
+  hasCookies,
+  hasAttachments
+} = useHttpDumpEvent(toRef(props, 'event'))
+
+const requestBodyLanguage = computed(() => {
+  const ct = contentType.value
+  if (!ct) return 'plaintext'
+  if (ct.includes('json')) return 'json'
+  if (ct.includes('xml')) return 'xml'
+  if (ct.includes('html')) return 'html'
+  return 'plaintext'
+})
+
+const isFormUrlEncoded = computed(
+  () => contentType.value?.includes('x-www-form-urlencoded') ?? false
+)
+
+const formParams = computed(() => {
+  if (!isFormUrlEncoded.value || !props.event.payload.request.body) return {}
+  const params: Record<string, string> = {}
+  for (const pair of props.event.payload.request.body.split('&')) {
+    const [key, ...rest] = pair.split('=')
+    if (key) {
+      params[decodeURIComponent(key)] = decodeURIComponent(rest.join('='))
+    }
+  }
+  return params
+})
+</script>
+
+<template>
+  <div class="flex flex-col gap-6">
+    <!-- Request Body (NEW — first section) -->
+    <EventDetailSection
+      v-if="hasBody"
+      title="Request Body"
+    >
+      <template #actions>
+        <HttpBodyViewToggle
+          v-if="bodyViewRef?.isJson"
+          :modes="['raw', 'pretty', 'tree']"
+          :active="bodyViewRef.viewMode"
+          @update:active="bodyViewRef.viewMode = $event"
+        />
+        <HttpBodyViewToggle
+          v-if="bodyViewRef?.isHtml"
+          :modes="['preview', 'source']"
+          :active="bodyViewRef.htmlMode"
+          @update:active="bodyViewRef.htmlMode = $event"
+        />
+      </template>
+
+      <!-- Form URL-encoded: render as table -->
+      <template v-if="isFormUrlEncoded">
+        <div class="flex items-center gap-2 mb-3">
+          <span
+            v-if="contentType"
+            class="http-tag"
+          >{{ contentType }}</span>
+          <span
+            v-if="bodySize"
+            class="http-tag"
+          >{{ bodySize }}</span>
+        </div>
+        <TableBase>
+          <TableBaseRow
+            v-for="(value, key) in formParams"
+            :key="key"
+            :title="String(key)"
+            :copy-value="String(value)"
+          >
+            {{ value }}
+          </TableBaseRow>
+        </TableBase>
+      </template>
+
+      <!-- Other bodies: HttpBodyView with Raw/Pretty/Tree toggle -->
+      <HttpBodyView
+        v-else
+        ref="bodyViewRef"
+        :body="event.payload.request.body"
+        :language="requestBodyLanguage"
+        :content-type="contentType || undefined"
+        :size="bodySize || undefined"
+      />
+    </EventDetailSection>
+
+    <!-- Query Parameters -->
+    <EventDetailSection
+      v-if="hasQuery"
+      title="Query Parameters"
+    >
+      <TableBase>
+        <TableBaseRow
+          v-for="(value, key) in event.payload.request.query"
+          :key="key"
+          :title="String(key)"
+          :copy-value="String(value)"
+        >
+          {{ value }}
+        </TableBaseRow>
+      </TableBase>
+    </EventDetailSection>
+
+    <!-- POST Data -->
+    <EventDetailSection
+      v-if="hasPostData"
+      title="POST Data"
+    >
+      <TableBase>
+        <TableBaseRow
+          v-for="(value, key) in event.payload.request.post"
+          :key="key"
+          :title="String(key)"
+          :copy-value="String(value)"
+        >
+          {{ value }}
+        </TableBaseRow>
+      </TableBase>
+    </EventDetailSection>
+
+    <!-- Request Headers -->
+    <EventDetailSection
+      v-if="hasHeaders"
+      title="Request Headers"
+    >
+      <TableBase>
+        <TableBaseRow
+          v-for="(value, key) in event.payload.request.headers"
+          :key="key"
+          :title="String(key)"
+          :copy-value="Array.isArray(value) ? value[0] : String(value)"
+        >
+          {{ Array.isArray(value) ? value[0] : value }}
+        </TableBaseRow>
+      </TableBase>
+    </EventDetailSection>
+
+    <!-- Cookies -->
+    <EventDetailSection
+      v-if="hasCookies"
+      title="Cookies"
+    >
+      <TableBase>
+        <TableBaseRow
+          v-for="(value, key) in event.payload.request.cookies"
+          :key="key"
+          :title="String(key)"
+          :copy-value="String(value)"
+        >
+          {{ value }}
+        </TableBaseRow>
+      </TableBase>
+    </EventDetailSection>
+
+    <!-- Attachments -->
+    <EventDetailSection
+      v-if="hasAttachments"
+      title="Attachments"
+      :count="event.payload.request.files?.length || 0"
+    >
+      <div class="flex gap-x-3">
+        <FileAttachment
+          v-for="file in event.payload.request.files"
+          :key="file.uuid"
+          :event-id="event.id"
+          :attachment="file"
+          :download-url="calcDownloadUrl(file.uuid)"
+        />
+      </div>
+    </EventDetailSection>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.http-tag {
+  @apply inline-flex items-center px-1.5 py-0.5 rounded;
+  @apply text-2xs font-mono;
+  @apply bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400;
+}
+</style>

--- a/src/entities/http-dump/ui/http-request-panel/index.ts
+++ b/src/entities/http-dump/ui/http-request-panel/index.ts
@@ -1,0 +1,1 @@
+export { default as HttpRequestPanel } from './http-request-panel.vue'

--- a/src/entities/http-dump/ui/http-response-panel/http-response-panel.stories.ts
+++ b/src/entities/http-dump/ui/http-response-panel/http-response-panel.stories.ts
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { useHttpDump } from '../../lib'
+import {
+  httpDumpProxyJsonMock,
+  httpDumpProxyHtmlMock,
+  httpDumpProxyXmlMock,
+  httpDumpProxyBinaryMock,
+  httpDumpProxy4xxMock,
+} from '../../mocks'
+import HttpResponsePanel from './http-response-panel.vue'
+
+const { normalizeHttpDumpEvent } = useHttpDump()
+
+export default {
+  title: 'Entities/HttpDump/HttpResponsePanel',
+  component: HttpResponsePanel,
+} as Meta<typeof HttpResponsePanel>
+
+export const JsonResponse: StoryObj<typeof HttpResponsePanel> = {
+  args: {
+    event: normalizeHttpDumpEvent(httpDumpProxyJsonMock),
+  },
+}
+
+export const HtmlResponse: StoryObj<typeof HttpResponsePanel> = {
+  args: {
+    event: normalizeHttpDumpEvent(httpDumpProxyHtmlMock),
+  },
+}
+
+export const XmlResponse: StoryObj<typeof HttpResponsePanel> = {
+  args: {
+    event: normalizeHttpDumpEvent(httpDumpProxyXmlMock),
+  },
+}
+
+export const BinaryResponse: StoryObj<typeof HttpResponsePanel> = {
+  args: {
+    event: normalizeHttpDumpEvent(httpDumpProxyBinaryMock),
+  },
+}
+
+export const ErrorResponse: StoryObj<typeof HttpResponsePanel> = {
+  args: {
+    event: normalizeHttpDumpEvent(httpDumpProxy4xxMock),
+  },
+}

--- a/src/entities/http-dump/ui/http-response-panel/http-response-panel.vue
+++ b/src/entities/http-dump/ui/http-response-panel/http-response-panel.vue
@@ -1,0 +1,131 @@
+<script lang="ts" setup>
+import { ref, toRef } from 'vue'
+import type { NormalizedEvent } from '@/shared/types'
+import { TableBase, TableBaseRow, EventDetailSection } from '@/shared/ui'
+import { useHttpDumpEvent } from '../../lib'
+import type { HttpDump } from '../../types'
+import { HttpBodyView } from '../http-body-view'
+import HttpBodyViewToggle from '../http-body-view/http-body-view-toggle.vue'
+
+type Props = {
+  event: NormalizedEvent<HttpDump>
+}
+
+const props = defineProps<Props>()
+
+const {
+  response,
+  responseContentType,
+  responseBodyLanguage,
+  isBinaryResponse,
+  responseBodySize,
+  hasResponseHeaders,
+  statusCode,
+  durationMs,
+  statusColor
+} = useHttpDumpEvent(toRef(props, 'event'))
+
+const bodyViewRef = ref<InstanceType<typeof HttpBodyView> | null>(null)
+</script>
+
+<template>
+  <div class="flex flex-col gap-6">
+    <!-- Status sub-header -->
+    <div class="http-response-status">
+      <span
+        v-if="statusCode"
+        class="http-response-status__badge"
+        :class="statusColor"
+      >{{
+        statusCode
+      }}</span>
+      <span
+        v-if="responseContentType"
+        class="http-tag"
+      >{{ responseContentType }}</span>
+      <span
+        v-if="responseBodySize"
+        class="http-tag"
+      >{{ responseBodySize }}</span>
+      <span
+        v-if="durationMs != null"
+        class="http-tag"
+      >{{ durationMs }}ms</span>
+    </div>
+
+    <!-- Response Body -->
+    <EventDetailSection
+      v-if="response?.body && !isBinaryResponse"
+      title="Response Body"
+    >
+      <template #actions>
+        <HttpBodyViewToggle
+          v-if="bodyViewRef?.isJson"
+          :modes="['raw', 'pretty', 'tree']"
+          :active="bodyViewRef.viewMode"
+          @update:active="bodyViewRef.viewMode = $event"
+        />
+        <HttpBodyViewToggle
+          v-if="bodyViewRef?.isHtml"
+          :modes="['preview', 'source']"
+          :active="bodyViewRef.htmlMode"
+          @update:active="bodyViewRef.htmlMode = $event"
+        />
+      </template>
+
+      <HttpBodyView
+        ref="bodyViewRef"
+        :body="response!.body"
+        :language="responseBodyLanguage"
+      />
+    </EventDetailSection>
+
+    <EventDetailSection
+      v-if="isBinaryResponse"
+      title="Response Body"
+    >
+      <div class="http-response-binary">
+        <span class="http-tag">{{ responseContentType }}</span>
+        <span class="http-tag">{{ responseBodySize }}</span>
+        <span class="text-xs text-gray-500 dark:text-gray-400">Binary content — not displayed</span>
+      </div>
+    </EventDetailSection>
+
+    <!-- Response Headers -->
+    <EventDetailSection
+      v-if="hasResponseHeaders"
+      title="Response Headers"
+    >
+      <TableBase>
+        <TableBaseRow
+          v-for="(value, key) in response!.headers"
+          :key="key"
+          :title="String(key)"
+          :copy-value="Array.isArray(value) ? value[0] : String(value)"
+        >
+          {{ Array.isArray(value) ? value[0] : value }}
+        </TableBaseRow>
+      </TableBase>
+    </EventDetailSection>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.http-response-status {
+  @apply flex items-center gap-2;
+}
+
+.http-response-status__badge {
+  @apply font-bold text-sm px-2 py-0.5 rounded uppercase tracking-wide;
+}
+
+.http-tag {
+  @apply inline-flex items-center px-1.5 py-0.5 rounded;
+  @apply text-2xs font-mono;
+  @apply bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400;
+}
+
+.http-response-binary {
+  @apply flex items-center gap-3 py-3;
+}
+</style>

--- a/src/entities/http-dump/ui/http-response-panel/index.ts
+++ b/src/entities/http-dump/ui/http-response-panel/index.ts
@@ -1,0 +1,1 @@
+export { default as HttpResponsePanel } from './http-response-panel.vue'

--- a/src/entities/http-dump/ui/index.ts
+++ b/src/entities/http-dump/ui/index.ts
@@ -1,2 +1,6 @@
 export * from './preview-card';
 export * from './http-dump-page';
+export * from './http-dump-header';
+export * from './http-request-panel';
+export * from './http-response-panel';
+export * from './http-body-view';

--- a/src/entities/http-dump/ui/preview-card/preview-card.stories.ts
+++ b/src/entities/http-dump/ui/preview-card/preview-card.stories.ts
@@ -1,6 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/vue3-vite";
 import { useHttpDump } from "../../lib";
-import { httpDumpMock } from '../../mocks';
+import {
+  httpDumpMock,
+  httpDumpProxyJsonMock,
+  httpDumpProxyHtmlMock,
+  httpDumpProxyErrorMock,
+  httpDumpProxy4xxMock,
+} from '../../mocks';
 import PreviewCard from './preview-card.vue';
 
 const { normalizeHttpDumpEvent } = useHttpDump();
@@ -16,3 +22,26 @@ export const Default: StoryObj<typeof PreviewCard> = {
   }
 }
 
+export const ProxyJson: StoryObj<typeof PreviewCard> = {
+  args: {
+    event: normalizeHttpDumpEvent(httpDumpProxyJsonMock),
+  }
+}
+
+export const ProxyHtml: StoryObj<typeof PreviewCard> = {
+  args: {
+    event: normalizeHttpDumpEvent(httpDumpProxyHtmlMock),
+  }
+}
+
+export const ProxyError: StoryObj<typeof PreviewCard> = {
+  args: {
+    event: normalizeHttpDumpEvent(httpDumpProxyErrorMock),
+  }
+}
+
+export const Proxy4xx: StoryObj<typeof PreviewCard> = {
+  args: {
+    event: normalizeHttpDumpEvent(httpDumpProxy4xxMock),
+  }
+}

--- a/src/entities/http-dump/ui/preview-card/preview-card.vue
+++ b/src/entities/http-dump/ui/preview-card/preview-card.vue
@@ -11,9 +11,30 @@ type Props = {
 
 const props = defineProps<Props>()
 
-const uri = computed(() => decodeURI(props.event.payload.request.uri))
+const isProxy = computed(() => !!props.event.payload.proxy)
 const eventLink = computed(() => `/http-dump/${props.event.id}`)
 const method = computed(() => props.event.payload.request.method)
+
+const uri = computed(() => {
+  const rawUri = decodeURI(props.event.payload.request.uri)
+  if (isProxy.value) {
+    const host = props.event.payload.host
+    return `${host}${rawUri}`
+  }
+  return rawUri
+})
+
+const statusCode = computed(() => props.event.payload.response?.status_code)
+const statusColor = computed(() => {
+  const code = statusCode.value
+  if (!code) return ''
+  if (code >= 500) return 'text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-500/10'
+  if (code >= 400) return 'text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-500/10'
+  if (code >= 300) return 'text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-500/10'
+  return 'text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-500/10'
+})
+
+const durationMs = computed(() => props.event.payload.duration_ms)
 
 const methodColor = computed(() => {
   const m = method.value?.toUpperCase()
@@ -112,12 +133,29 @@ const copyCurl = () => {
           class="http-body__method"
           :class="methodColor"
         >{{ method }}</span>
+        <span
+          v-if="statusCode"
+          class="http-body__method"
+          :class="statusColor"
+        >{{
+          statusCode
+        }}</span>
         <span class="http-body__uri">{{ uri }}</span>
       </div>
 
       <div class="http-body__meta">
         <span
-          v-if="host"
+          v-if="isProxy"
+          class="http-body__tag http-body__tag--proxy"
+        >proxy</span>
+
+        <span
+          v-if="durationMs != null"
+          class="http-body__tag"
+        >{{ durationMs }}ms</span>
+
+        <span
+          v-if="!isProxy && host"
           class="http-body__tag"
         >{{ host }}</span>
 
@@ -195,5 +233,9 @@ const copyCurl = () => {
   @apply inline-flex items-center px-1.5 py-0.5 rounded;
   @apply text-2xs font-mono;
   @apply bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400;
+}
+
+.http-body__tag--proxy {
+  @apply bg-violet-100 dark:bg-violet-500/10 text-violet-600 dark:text-violet-400;
 }
 </style>

--- a/src/entities/http-dump/ui/preview-card/preview-card.vue
+++ b/src/entities/http-dump/ui/preview-card/preview-card.vue
@@ -1,8 +1,9 @@
 <script lang="ts" setup>
-import { computed, ref } from 'vue'
+import { ref, toRef } from 'vue'
 import { copyTextToClipboard } from '@/shared/lib/clipboard'
 import type { NormalizedEvent } from '@/shared/types'
 import { PreviewCard, IconSvg } from '@/shared/ui'
+import { useHttpDumpEvent } from '../../lib'
 import type { HttpDump } from '../../types'
 
 type Props = {
@@ -11,96 +12,31 @@ type Props = {
 
 const props = defineProps<Props>()
 
-const isProxy = computed(() => !!props.event.payload.proxy)
-const eventLink = computed(() => `/http-dump/${props.event.id}`)
-const method = computed(() => props.event.payload.request.method)
+const {
+  isProxy,
+  method,
+  uri,
+  host,
+  contentType,
+  statusCode,
+  durationMs,
+  methodColor,
+  statusColor,
+  borderStatusClass,
+  queryCount,
+  headerCount,
+  hasBody,
+  bodySize,
+  curlCommand
+} = useHttpDumpEvent(toRef(props, 'event'))
 
-const uri = computed(() => {
-  const rawUri = decodeURI(props.event.payload.request.uri)
-  if (isProxy.value) {
-    const host = props.event.payload.host
-    return `${host}${rawUri}`
-  }
-  return rawUri
-})
-
-const statusCode = computed(() => props.event.payload.response?.status_code)
-const statusColor = computed(() => {
-  const code = statusCode.value
-  if (!code) return ''
-  if (code >= 500) return 'text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-500/10'
-  if (code >= 400) return 'text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-500/10'
-  if (code >= 300) return 'text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-500/10'
-  return 'text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-500/10'
-})
-
-const durationMs = computed(() => props.event.payload.duration_ms)
-
-const methodColor = computed(() => {
-  const m = method.value?.toUpperCase()
-  if (m === 'GET') return 'text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-500/10'
-  if (m === 'POST') return 'text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-500/10'
-  if (m === 'PUT' || m === 'PATCH')
-    return 'text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-500/10'
-  if (m === 'DELETE') return 'text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-500/10'
-  return 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-500/10'
-})
-
-const host = computed(() => {
-  const h = props.event.payload.request.headers?.host
-  if (!h) return null
-  return Array.isArray(h) ? h[0] : h
-})
-
-const contentType = computed(() => {
-  const ct =
-    props.event.payload.request.headers?.['content-type'] ||
-    props.event.payload.request.headers?.['Content-Type']
-  if (!ct) return null
-  const val = Array.isArray(ct) ? ct[0] : ct
-  return val?.split(';')[0]?.trim() || null
-})
-
-const queryCount = computed(() => Object.keys(props.event.payload.request.query || {}).length)
-const headerCount = computed(() => Object.keys(props.event.payload.request.headers || {}).length)
-const hasBody = computed(() => (props.event.payload.request.body?.length || 0) > 0)
-
-const bodySize = computed(() => {
-  const len = props.event.payload.request.body?.length || 0
-  if (!len) return null
-  if (len < 1024) return `${len} B`
-  return `${(len / 1024).toFixed(1)} KB`
-})
+const eventLink = `/http-dump/${props.event.id}`
 
 const isCopied = ref(false)
 
-const buildCurl = (): string => {
-  const req = props.event.payload.request
-  let curl = `curl -X ${req.method}`
-
-  if (host.value) {
-    curl += ` '${host.value}${req.uri}'`
-  } else {
-    curl += ` '${req.uri}'`
-  }
-
-  const headers = req.headers || {}
-  for (const [key, val] of Object.entries(headers)) {
-    if (key.toLowerCase() === 'host') continue
-    const v = Array.isArray(val) ? val[0] : val
-    curl += ` \\\n  -H '${key}: ${v}'`
-  }
-
-  if (req.body) {
-    curl += ` \\\n  -d '${req.body.replace(/'/g, "'\\''")}'`
-  }
-
-  return curl
-}
-
 const copyCurl = () => {
   isCopied.value = true
-  copyTextToClipboard(buildCurl()).catch(console.error)
+  copyTextToClipboard(curlCommand.value).catch(console.error)
   setTimeout(() => {
     isCopied.value = false
   }, 1500)
@@ -112,6 +48,7 @@ const copyCurl = () => {
     <RouterLink
       :to="eventLink"
       class="http-body"
+      :class="borderStatusClass"
     >
       <!-- Copy cURL button (top-right, hover reveal) -->
       <button
@@ -140,7 +77,10 @@ const copyCurl = () => {
         >{{
           statusCode
         }}</span>
-        <span class="http-body__uri">{{ uri }}</span>
+        <span
+          class="http-body__uri"
+          :title="uri"
+        >{{ uri }}</span>
       </div>
 
       <div class="http-body__meta">
@@ -184,7 +124,7 @@ const copyCurl = () => {
 .http-body {
   @apply relative block p-3 rounded cursor-pointer;
   @apply bg-gray-50 dark:bg-gray-900;
-  @apply border border-gray-200 dark:border-gray-700;
+  @apply border border-l-[3px] border-gray-200 dark:border-gray-700;
   @apply hover:border-gray-300 dark:hover:border-gray-600 transition-colors;
 }
 
@@ -214,7 +154,7 @@ const copyCurl = () => {
 }
 
 .http-body__row {
-  @apply flex items-baseline gap-2 font-mono text-xs mb-2;
+  @apply flex items-baseline gap-2 font-mono text-xs mb-2 min-w-0;
 }
 
 .http-body__method {
@@ -222,7 +162,8 @@ const copyCurl = () => {
 }
 
 .http-body__uri {
-  @apply text-gray-700 dark:text-gray-200 break-all;
+  @apply text-gray-700 dark:text-gray-200 truncate;
+  min-width: 0;
 }
 
 .http-body__meta {

--- a/src/shared/lib/io/use-events-requests.ts
+++ b/src/shared/lib/io/use-events-requests.ts
@@ -12,6 +12,7 @@ type TUseEventsRequests = () => {
   deleteByType: (type: EventType) => Promise<void | Response>,
   pinEvent: (id: EventId) => Promise<void | Response>,
   unpinEvent: (id: EventId) => Promise<void | Response>,
+  replayHttpDump: (id: EventId) => Promise<void | Response>,
 }
 
 // TODO: add 403 response handling
@@ -110,6 +111,14 @@ export const useEventsRequests: TUseEventsRequests = () => {
     console.error('Unpin Error', err)
   })
 
+  const replayHttpDump = (id: EventId): Promise<void | Response> =>
+    fetch(`${REST_API_URL}/api/http-dump/${id}/replay`, {
+      method: 'POST',
+      headers,
+    }).catch((err) => {
+      console.error('Replay Error', err)
+    })
+
   return {
     getAll,
     getSingle,
@@ -119,5 +128,6 @@ export const useEventsRequests: TUseEventsRequests = () => {
     deleteByType,
     pinEvent,
     unpinEvent,
+    replayHttpDump,
   }
 }

--- a/src/shared/ui/code-snippet/code-snippet.vue
+++ b/src/shared/ui/code-snippet/code-snippet.vue
@@ -67,6 +67,7 @@ const copyCode = (): void => {
 .code-snippet {
   @apply relative rounded overflow-hidden;
   @apply bg-gray-50 dark:bg-gray-900;
+  @apply border border-gray-200 dark:border-gray-700;
 
   :deep(pre) {
     @apply m-0;

--- a/src/shared/ui/event-detail-layout/event-detail-layout.vue
+++ b/src/shared/ui/event-detail-layout/event-detail-layout.vue
@@ -46,7 +46,7 @@ const formattedDate = computed(() =>
 
 <style lang="scss" scoped>
 .event-detail {
-  @apply relative flex flex-col h-full;
+  @apply relative flex flex-col;
 }
 
 .event-detail__header {

--- a/src/shared/ui/event-detail-layout/event-detail-section.vue
+++ b/src/shared/ui/event-detail-layout/event-detail-section.vue
@@ -15,18 +15,24 @@ withDefaults(defineProps<Props>(), {
     v-if="$slots.default"
     class="event-section"
   >
-    <h3
-      v-if="title"
-      class="event-section__title"
+    <div
+      v-if="title || $slots.actions"
+      class="event-section__header"
     >
-      {{ title }}
-      <span
-        v-if="count > 0"
-        class="event-section__count"
+      <h3
+        v-if="title"
+        class="event-section__title"
       >
-        {{ count }}
-      </span>
-    </h3>
+        {{ title }}
+        <span
+          v-if="count > 0"
+          class="event-section__count"
+        >
+          {{ count }}
+        </span>
+      </h3>
+      <slot name="actions" />
+    </div>
     <div class="event-section__content">
       <slot />
     </div>
@@ -34,10 +40,13 @@ withDefaults(defineProps<Props>(), {
 </template>
 
 <style lang="scss" scoped>
+.event-section__header {
+  @apply flex items-center justify-between gap-2 mb-3;
+}
+
 .event-section__title {
   @apply text-xs font-mono font-semibold uppercase tracking-wider;
   @apply text-gray-500 dark:text-gray-400;
-  @apply mb-3;
 }
 
 .event-section__count {

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -14,3 +14,4 @@ export * from './page-tabs';
 export * from './skeleton-loader';
 export * from './search-bar';
 export * from './highlight-text';
+export * from './json-tree-view';

--- a/src/shared/ui/json-tree-view/index.ts
+++ b/src/shared/ui/json-tree-view/index.ts
@@ -1,0 +1,2 @@
+export { default as JsonTreeView } from './json-tree-view.vue'
+export { useJsonTree } from './use-json-tree'

--- a/src/shared/ui/json-tree-view/json-tree-node.vue
+++ b/src/shared/ui/json-tree-view/json-tree-node.vue
@@ -1,0 +1,242 @@
+<script lang="ts" setup>
+import { computed, ref } from 'vue'
+import { copyTextToClipboard } from '../../lib/clipboard'
+
+type Props = {
+  nodeKey: string | number | null
+  value: unknown
+  depth: number
+  path: string
+}
+
+const props = defineProps<Props>()
+
+const isObject = computed(
+  () => props.value !== null && typeof props.value === 'object' && !Array.isArray(props.value)
+)
+const isArray = computed(() => Array.isArray(props.value))
+const isExpandable = computed(() => isObject.value || isArray.value)
+const isCollapsed = ref(props.depth > 1)
+const toggle = () => {
+  isCollapsed.value = !isCollapsed.value
+}
+
+const childEntries = computed(() => {
+  if (isArray.value) {
+    return (props.value as unknown[]).map((v, i) => ({
+      key: i,
+      value: v,
+      path: props.path ? `${props.path}[${i}]` : `[${i}]`
+    }))
+  }
+  if (isObject.value) {
+    return Object.entries(props.value as Record<string, unknown>).map(([k, v]) => ({
+      key: k,
+      value: v,
+      path: props.path ? `${props.path}.${k}` : k
+    }))
+  }
+  return []
+})
+
+const childCount = computed(() => childEntries.value.length)
+const bracketOpen = computed(() => (isArray.value ? '[' : '{'))
+const bracketClose = computed(() => (isArray.value ? ']' : '}'))
+const collapsedLabel = computed(() =>
+  isArray.value ? `[${childCount.value} items]` : `{${childCount.value} keys}`
+)
+
+const valueType = computed(() => {
+  if (props.value === null) return 'null'
+  if (typeof props.value === 'boolean') return 'boolean'
+  if (typeof props.value === 'number') return 'number'
+  if (typeof props.value === 'string') return 'string'
+  return 'other'
+})
+
+const isLongString = computed(
+  () => valueType.value === 'string' && (props.value as string).length > 100
+)
+const isStringExpanded = ref(false)
+const displayString = computed(() => {
+  const s = props.value as string
+  if (!isLongString.value || isStringExpanded.value) return s
+  return s.slice(0, 100)
+})
+
+const isCopied = ref(false)
+const copyPath = () => {
+  if (!props.path) return
+  isCopied.value = true
+  copyTextToClipboard(props.path).catch(console.error)
+  setTimeout(() => {
+    isCopied.value = false
+  }, 1500)
+}
+</script>
+
+<template>
+  <div class="json-node">
+    <div class="json-node__line">
+      <!-- Toggle arrow -->
+      <button
+        v-if="isExpandable"
+        class="json-node__toggle"
+        @click="toggle"
+      >
+        <span :class="isCollapsed ? 'json-node__arrow--right' : 'json-node__arrow--down'">▶</span>
+      </button>
+      <span
+        v-else
+        class="json-node__spacer"
+      />
+
+      <!-- Key -->
+      <span
+        v-if="nodeKey !== null"
+        class="json-node__key"
+        :title="isCopied ? 'Copied!' : `Copy path: ${path}`"
+        @click="copyPath"
+      >{{ nodeKey }}<span class="json-node__colon">:</span></span>
+
+      <!-- Expandable collapsed -->
+      <template v-if="isExpandable && isCollapsed">
+        <span
+          class="json-node__collapsed"
+          @click="toggle"
+        >{{ collapsedLabel }}</span>
+      </template>
+
+      <!-- Expandable expanded (opening bracket) -->
+      <template v-if="isExpandable && !isCollapsed">
+        <span class="json-node__bracket">{{ bracketOpen }}</span>
+      </template>
+
+      <!-- Primitive values -->
+      <template v-if="!isExpandable">
+        <span
+          v-if="valueType === 'null'"
+          class="json-node__value json-node__value--null"
+        >null</span>
+        <span
+          v-else-if="valueType === 'boolean'"
+          class="json-node__value json-node__value--boolean"
+        >{{ value }}</span>
+        <span
+          v-else-if="valueType === 'number'"
+          class="json-node__value json-node__value--number"
+        >{{ value }}</span>
+        <span
+          v-else-if="valueType === 'string'"
+          class="json-node__value json-node__value--string"
+        >"{{ displayString }}"<button
+          v-if="isLongString"
+          class="json-node__expand-str"
+          @click="isStringExpanded = !isStringExpanded"
+        >
+          {{ isStringExpanded ? 'collapse' : '…expand' }}
+        </button></span>
+      </template>
+    </div>
+
+    <!-- Children -->
+    <div
+      v-if="isExpandable && !isCollapsed"
+      class="json-node__children"
+    >
+      <JsonTreeNode
+        v-for="child in childEntries"
+        :key="child.key"
+        :node-key="child.key"
+        :value="child.value"
+        :depth="depth + 1"
+        :path="child.path"
+      />
+    </div>
+
+    <!-- Closing bracket -->
+    <div
+      v-if="isExpandable && !isCollapsed"
+      class="json-node__line"
+    >
+      <span class="json-node__spacer" />
+      <span class="json-node__bracket">{{ bracketClose }}</span>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.json-node {
+  @apply font-mono text-xs leading-relaxed;
+}
+
+.json-node__line {
+  @apply flex items-start gap-0;
+  padding-left: 0;
+}
+
+.json-node__toggle {
+  @apply w-4 h-4 flex items-center justify-center cursor-pointer flex-shrink-0;
+  @apply text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300;
+  font-size: 8px;
+}
+
+.json-node__arrow--right {
+  display: inline-block;
+  transition: transform 0.1s;
+}
+
+.json-node__arrow--down {
+  display: inline-block;
+  transform: rotate(90deg);
+  transition: transform 0.1s;
+}
+
+.json-node__spacer {
+  @apply w-4 flex-shrink-0 inline-block;
+}
+
+.json-node__key {
+  @apply text-purple-700 dark:text-purple-400 cursor-pointer flex-shrink-0;
+  @apply hover:underline;
+}
+
+.json-node__colon {
+  @apply text-gray-500 dark:text-gray-400 mr-1;
+}
+
+.json-node__bracket {
+  @apply text-gray-500 dark:text-gray-400;
+}
+
+.json-node__collapsed {
+  @apply text-gray-400 dark:text-gray-500 cursor-pointer;
+  @apply hover:text-gray-600 dark:hover:text-gray-300;
+}
+
+.json-node__value--null {
+  @apply text-gray-400 dark:text-gray-500 italic;
+}
+
+.json-node__value--boolean {
+  @apply text-amber-600 dark:text-amber-400;
+}
+
+.json-node__value--number {
+  @apply text-blue-600 dark:text-blue-400;
+}
+
+.json-node__value--string {
+  @apply text-green-700 dark:text-green-400;
+  word-break: break-all;
+}
+
+.json-node__expand-str {
+  @apply text-2xs text-gray-400 dark:text-gray-500 ml-1 cursor-pointer;
+  @apply hover:text-gray-600 dark:hover:text-gray-300;
+}
+
+.json-node__children {
+  padding-left: 16px;
+}
+</style>

--- a/src/shared/ui/json-tree-view/json-tree-view.stories.ts
+++ b/src/shared/ui/json-tree-view/json-tree-view.stories.ts
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import JsonTreeView from './json-tree-view.vue'
+
+export default {
+  title: 'Shared/JsonTreeView',
+  component: JsonTreeView,
+} as Meta<typeof JsonTreeView>
+
+const nestedFixture = {
+  id: 101,
+  title: 'Buggregator proxy test',
+  user: {
+    id: 42,
+    name: 'John Doe',
+    email: 'john@example.com',
+    address: {
+      street: '123 Main St',
+      city: 'Springfield',
+      state: 'IL',
+      zip: '62701',
+      geo: { lat: 39.7817, lng: -89.6501 },
+    },
+    tags: ['admin', 'developer', 'tester'],
+  },
+  items: [
+    { sku: 'WIDGET-001', name: 'Widget', qty: 3, price: 9.99 },
+    { sku: 'GADGET-002', name: 'Gadget', qty: 1, price: 24.99 },
+  ],
+  metadata: {
+    created_at: '2026-04-04T12:00:00Z',
+    updated_at: null,
+    is_active: true,
+    description:
+      'This is a very long string value that exceeds one hundred characters in length and should be truncated by the tree view component with an expand button shown inline.',
+  },
+}
+
+export const Default: StoryObj<typeof JsonTreeView> = {
+  args: {
+    value: nestedFixture,
+  },
+}
+
+export const SimpleArray: StoryObj<typeof JsonTreeView> = {
+  args: {
+    value: [1, 'hello', true, null, { nested: 'object' }],
+  },
+}
+
+export const PrimitiveString: StoryObj<typeof JsonTreeView> = {
+  args: {
+    value: 'Just a string value',
+  },
+}
+
+export const EmptyObject: StoryObj<typeof JsonTreeView> = {
+  args: {
+    value: {},
+  },
+}
+
+export const DeeplyNested: StoryObj<typeof JsonTreeView> = {
+  args: {
+    value: {
+      level1: {
+        level2: {
+          level3: {
+            level4: {
+              level5: {
+                value: 'deep!',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}

--- a/src/shared/ui/json-tree-view/json-tree-view.vue
+++ b/src/shared/ui/json-tree-view/json-tree-view.vue
@@ -1,0 +1,81 @@
+<script lang="ts" setup>
+import { computed } from 'vue'
+import JsonTreeNode from './json-tree-node.vue'
+
+type Props = {
+  value: unknown
+}
+
+const props = defineProps<Props>()
+
+const isObject = computed(
+  () => props.value !== null && typeof props.value === 'object' && !Array.isArray(props.value)
+)
+const isArray = computed(() => Array.isArray(props.value))
+
+const entries = computed(() => {
+  if (isArray.value) {
+    return (props.value as unknown[]).map((v, i) => ({
+      key: i,
+      value: v,
+      path: `[${i}]`
+    }))
+  }
+  if (isObject.value) {
+    return Object.entries(props.value as Record<string, unknown>).map(([k, v]) => ({
+      key: k,
+      value: v,
+      path: k
+    }))
+  }
+  return []
+})
+
+const isPrimitive = computed(() => !isObject.value && !isArray.value)
+const isEmpty = computed(() => !isPrimitive.value && entries.value.length === 0)
+const emptyLabel = computed(() => (isArray.value ? '[]' : '{}'))
+</script>
+
+<template>
+  <div class="json-tree-view">
+    <!-- Primitive root value -->
+    <JsonTreeNode
+      v-if="isPrimitive"
+      :node-key="null"
+      :value="value"
+      :depth="0"
+      path=""
+    />
+
+    <!-- Empty object/array -->
+    <span
+      v-else-if="isEmpty"
+      class="json-tree-view__empty"
+    >{{ emptyLabel }}</span>
+
+    <!-- Object/Array root -->
+    <template v-else>
+      <JsonTreeNode
+        v-for="entry in entries"
+        :key="entry.key"
+        :node-key="entry.key"
+        :value="entry.value"
+        :depth="0"
+        :path="entry.path"
+      />
+    </template>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.json-tree-view {
+  @apply p-3 rounded;
+  @apply bg-gray-50 dark:bg-gray-900;
+  @apply border border-gray-200 dark:border-gray-700;
+  @apply overflow-x-auto;
+}
+
+.json-tree-view__empty {
+  @apply font-mono text-xs text-gray-400 dark:text-gray-500 italic;
+}
+</style>

--- a/src/shared/ui/json-tree-view/use-json-tree.ts
+++ b/src/shared/ui/json-tree-view/use-json-tree.ts
@@ -1,0 +1,20 @@
+import { computed, ref, type Ref } from 'vue'
+
+export const useJsonTree = (raw: Ref<string | null>) => {
+  const parseError = ref<string | null>(null)
+
+  const parsed = computed(() => {
+    if (!raw.value) return null
+    try {
+      parseError.value = null
+      return JSON.parse(raw.value)
+    } catch (e) {
+      parseError.value = String(e)
+      return null
+    }
+  })
+
+  const isJson = computed(() => parsed.value !== null)
+
+  return { parsed, parseError, isJson }
+}

--- a/src/shared/ui/table-base/table-base-row.vue
+++ b/src/shared/ui/table-base/table-base-row.vue
@@ -1,20 +1,64 @@
 <script lang="ts" setup>
+import { ref } from 'vue'
+import { copyTextToClipboard } from '../../lib/clipboard'
+
 type Props = {
   title?: string
+  copyValue?: string
 }
 
-withDefaults(defineProps<Props>(), {
-  title: ''
+const props = withDefaults(defineProps<Props>(), {
+  title: '',
+  copyValue: ''
 })
+
+const isCopied = ref(false)
+
+const copyRow = () => {
+  if (!props.copyValue) return
+  isCopied.value = true
+  copyTextToClipboard(props.copyValue).catch(console.error)
+  setTimeout(() => {
+    isCopied.value = false
+  }, 1500)
+}
 </script>
 
 <template>
-  <div class="table-row">
+  <div class="table-row group">
     <div class="table-row__name">
       <span :title="title">{{ title }}</span>
     </div>
     <div class="table-row__value">
       <slot />
+      <button
+        v-if="copyValue"
+        class="table-row__copy"
+        :class="{ 'table-row__copy--active': isCopied }"
+        :title="isCopied ? 'Copied!' : 'Copy value'"
+        @click.stop="copyRow"
+      >
+        <svg
+          class="w-3 h-3"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          stroke-width="2"
+        >
+          <path
+            v-if="isCopied"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M5 13l4 4L19 7"
+          />
+          <path
+            v-else
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+          />
+        </svg>
+      </button>
     </div>
   </div>
 </template>
@@ -38,5 +82,21 @@ withDefaults(defineProps<Props>(), {
 
 .table-row__value {
   @apply break-all md:w-3/4 md:pl-3 font-mono text-gray-700 dark:text-gray-200;
+  @apply flex items-center gap-1;
+}
+
+.table-row__copy {
+  @apply opacity-0 flex-shrink-0 p-0.5 rounded cursor-pointer;
+  @apply text-gray-400 dark:text-gray-500;
+  @apply hover:text-gray-600 dark:hover:text-gray-300;
+  @apply transition-opacity duration-150;
+
+  .group:hover & {
+    @apply opacity-100;
+  }
+}
+
+.table-row__copy--active {
+  @apply opacity-100 text-green-600 dark:text-green-400;
 }
 </style>

--- a/src/widgets/ui/layout-base/layout-base.vue
+++ b/src/widgets/ui/layout-base/layout-base.vue
@@ -157,9 +157,10 @@ watch(
 
 .layout-base__content {
   @include mixins.layout-body;
+  @apply overflow-y-auto;
 
   & > div {
-    @apply flex flex-col h-full flex-1;
+    @apply flex flex-col min-h-full flex-1;
   }
 
   .layout-base--no-sidebar & {
@@ -195,11 +196,15 @@ watch(
 }
 
 .toast-enter-active {
-  transition: opacity 0.15s ease, transform 0.15s ease;
+  transition:
+    opacity 0.15s ease,
+    transform 0.15s ease;
 }
 
 .toast-leave-active {
-  transition: opacity 0.2s ease, transform 0.2s ease;
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
 }
 
 .toast-enter-from {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,7 +34,10 @@ export default defineConfig({
   },
   server: {
     host: 'localhost',
-    port: 3000
+    port: 3000,
+    watch: {
+      usePolling: !!process.env.CHOKIDAR_USEPOLLING,
+    },
   },
   build: {
     rollupOptions: {


### PR DESCRIPTION
## What
Extends the http-dump entity to display proxied HTTP requests with full request/response data, syntax-highlighted response bodies, and visual indicators for proxy origin.

## Why
The server now supports an HTTP proxy module that captures traffic as http-dump events with additional `response`, `proxy`, and `duration_ms` fields. The frontend needs to display this data.

## How
- **Types**: added `HttpDumpResponse`, `proxy`, `duration_ms`, `error`, `response` fields
- **Normalizer**: adds colored labels (proxy badge, status code, duration), builds full URL for proxy
- **Preview card**: shows full URL, status code badge, proxy tag, duration
- **Detail page**: new Response Headers table, Response Body with syntax highlighting (JSON/HTML/XML/CSS/JS), HTML iframe preview, binary content indicator, proxy error display
- **Mocks**: 6 new JSON files covering JSON, HTML, XML, binary, 4xx, connection error scenarios
- **Stories**: PreviewCard (5 variants), HttpDumpPage (8 variants)

## Testing
- `vue-tsc --noEmit` — no type errors
- `eslint` — clean
- Storybook: open `Entities/HttpDump/PreviewCard` and `Entities/HttpDump/HttpDumpPage` to see all variants