### PR TITLE
fix: update attachment URLs for new server route layout

### DIFF
--- a/src/shared/lib/io/use-attachments.ts
+++ b/src/shared/lib/io/use-attachments.ts
@@ -15,7 +15,11 @@ export const useAttachments: TUseAttachments = (module: EventModule = 'smtp') =>
 
   const headers = {"X-Auth-Token": token.value }
 
-  const calcDownloadLink = (id: EventId, attachmentId?: string): string => `${REST_API_URL}/api/${module}/${id}/attachments${attachmentId ? `/${attachmentId}` : ''}`
+  // The server namespaces attachment endpoints under `/api/{module}/attachments/...`
+  // (literal `attachments` segment first) to avoid colliding with module routes
+  // like `/api/smtp/message/{uuid}/raw`. See server: internal/server/http/attachments.go.
+  const calcDownloadLink = (id: EventId, attachmentId?: string): string =>
+    `${REST_API_URL}/api/${module}/attachments/${id}${attachmentId ? `/${attachmentId}` : ''}`
 
   const getAttachments = (id: EventId) => fetch(calcDownloadLink(id), { headers })
     .then((response) => response.json())


### PR DESCRIPTION
## What
Updates the client to call attachments through `/api/{module}/attachments/{eventUuid}[/{uuid}]`.

## Why
Companion to [buggregator/server#336](https://github.com/buggregator/server/pull/336). The server's previous attachment layout (`/api/{module}/{eventUuid}/attachments/{uuid}`) collided with the new SMTP message routes and made the server panic at startup. The server PR nests attachments under a literal `attachments` segment to break the conflict; this PR keeps the frontend in sync.

## Testing
Manual: open an SMTP event in the UI and confirm the attachments list and download links work against a server built with the companion PR.