### PR TITLE
Increase Sentry frame limit

### DIFF
--- a/src/entities/sentry/ui/sentry-page/sentry-page.vue
+++ b/src/entities/sentry/ui/sentry-page/sentry-page.vue
@@ -281,7 +281,7 @@ watch(
                 >Caused by</span>
                 <SentryException
                   :exception="e"
-                  :max-frames="10"
+                  :max-frames="250"
                 />
               </div>
             </div>


### PR DESCRIPTION
## What was changed

Increased the frame limit to 250 frames in the Sentry page.

## Why?

The frames shown in the Sentry page are currently limited to 10 frames. When the cause of an exception is after these 10 frames, one has to find the frame in the issue's JSON data. This frequently happens in frameworks like Laravel where there's usually at least 100 frames in a stack trace and the culprit is beyond the first 10 frames.

I'm using this branch in a Laravel project and haven't seen any issues.

## Checklist

- Tested
    - [x] Tested manually
    - [ ] Unit tests added