### PR TITLE
Add SMS to sidebar

### DIFF
--- a/src/shared/lib/use-global-shortcuts/use-global-shortcuts.ts
+++ b/src/shared/lib/use-global-shortcuts/use-global-shortcuts.ts
@@ -7,6 +7,7 @@ const NAV_TYPES: EventTypes[] = [
   EventTypes.Sentry,
   EventTypes.Profiler,
   EventTypes.Smtp,
+  EventTypes.Sms,
   EventTypes.HttpDump,
   EventTypes.Inspector,
   EventTypes.VarDump,

--- a/src/shared/ui/icon-svg/icon-svg-originals/sms.svg
+++ b/src/shared/ui/icon-svg/icon-svg-originals/sms.svg
@@ -1,6 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
-  <path d="M8 10h.01"/>
-  <path d="M12 10h.01"/>
-  <path d="M16 10h.01"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path fill-rule="evenodd" d="M20 2H4C2.9 2 2 2.9 2 4v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zM8 8.5a1.5 1.5 0 1 0 0 3 1.5 1.5 0 1 0 0-3zm4 0a1.5 1.5 0 1 0 0 3 1.5 1.5 0 1 0 0-3zm4 0a1.5 1.5 0 1 0 0 3 1.5 1.5 0 1 0 0-3z" />
 </svg>

--- a/src/shared/ui/icon-svg/icon-svg.vue
+++ b/src/shared/ui/icon-svg/icon-svg.vue
@@ -574,6 +574,16 @@ defineProps<Props>()
     </svg>
 
     <svg
+      v-else-if="name === 'sms'"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M19,1H5A5.006,5.006,0,0,0,0,6V23l5-5H19a5.006,5.006,0,0,0,5-5V6A5.006,5.006,0,0,0,19,1ZM22,13a3,3,0,0,1-3,3H4.17L2,18.17V6A3,3,0,0,1,5,3H19a3,3,0,0,1,3,3ZM6,9H8v2H6Zm5,0h2v2H11Zm5,0h2v2H16Z"
+      />
+    </svg>
+
+    <svg
       v-else-if="name === 'settings'"
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 24 24"

--- a/src/widgets/ui/keyboard-shortcuts-overlay/keyboard-shortcuts-overlay.vue
+++ b/src/widgets/ui/keyboard-shortcuts-overlay/keyboard-shortcuts-overlay.vue
@@ -12,11 +12,12 @@ const sections = [
       { keys: ['1'], desc: 'Sentry' },
       { keys: ['2'], desc: 'Profiler' },
       { keys: ['3'], desc: 'SMTP' },
-      { keys: ['4'], desc: 'HTTP Dump' },
-      { keys: ['5'], desc: 'Inspector' },
-      { keys: ['6'], desc: 'VarDump' },
-      { keys: ['7'], desc: 'Monolog' },
-      { keys: ['8'], desc: 'Ray' }
+      { keys: ['4'], desc: 'SMS' },
+      { keys: ['5'], desc: 'HTTP Dump' },
+      { keys: ['6'], desc: 'Inspector' },
+      { keys: ['7'], desc: 'VarDump' },
+      { keys: ['8'], desc: 'Monolog' },
+      { keys: ['9'], desc: 'Ray' }
     ]
   },
   {

--- a/src/widgets/ui/layout-sidebar/constants.ts
+++ b/src/widgets/ui/layout-sidebar/constants.ts
@@ -4,6 +4,7 @@ export const EVENTS_NAV_ORDER: EventTypes[] = [
   EventTypes.Sentry,
   EventTypes.Profiler,
   EventTypes.Smtp,
+  EventTypes.Sms,
   EventTypes.HttpDump,
   EventTypes.Inspector,
   EventTypes.VarDump,

--- a/src/widgets/ui/layout-sidebar/layout-sidebar.vue
+++ b/src/widgets/ui/layout-sidebar/layout-sidebar.vue
@@ -616,6 +616,7 @@ $dotColors: (
   'sentry': 'rose',
   'profiler': 'violet',
   'smtp': 'amber',
+  'sms': 'indigo',
   'http-dump': 'green',
   'inspector': 'yellow',
   'var-dump': 'orange',


### PR DESCRIPTION
## What was changed

Added SMS to the sidebar navigation directly below SMTP.

Updated the numeric navigation shortcuts to match the new sidebar order:
- `4` now opens SMS
- HTTP Dump and following items shift down by one key

Changed the SMS sidebar icon to use an outline style and adjusted its visual size so it is consistent with the other sidebar icons.

## Why?

SMS events should be reachable from the main sidebar like the other event types.

## Checklist

- Tested
    - [x] Tested manually
    - [ ] Unit tests added